### PR TITLE
feat(menu): main menu + multi-game framework

### DIFF
--- a/docs/adding-a-game.md
+++ b/docs/adding-a-game.md
@@ -2,10 +2,6 @@
 
 A walkthrough that should let you ship a new classic in a single PR.
 
-> The framework that makes this slick lands in task #6. Until then, follow the
-> structure below by hand and the menu integration will be a one-liner once #6
-> ships.
-
 ## 1. Open a tracking issue
 
 Use the `Task` template. Fill in PRD, deliverables, acceptance, tests. Move the
@@ -22,39 +18,60 @@ godot/
 │   │   └── ...
 │   └── controller.gd          # Glues core to the scene
 ├── scenes/<game>/
-│   ├── <game>.tscn            # Root scene, implements the Game contract
+│   ├── <game>.tscn            # Root scene, implements the GameHost contract
 │   └── <game>.gd
 └── tests/unit/<game>/
     └── test_*.gd
 ```
 
-## 3. Implement the `Game` scene contract
+## 3. Implement the GameHost contract
 
-(API stabilises in task #6.)
+The menu launches a game by instancing its root scene and calling lifecycle
+methods on the root node. The contract is **duck-typed** — any node that
+implements these methods and emits `exit_requested` qualifies, regardless of
+whether it extends `Control`, `Node2D`, or `Node`.
 
 ```gdscript
-extends Control
-class_name Game
+extends Control  # or Node2D / Node — whatever the game needs
 
-signal score_reported(value: int)
-signal exited
+signal exit_requested()              # game wants to return to menu
+signal score_reported(value: int)    # optional but recommended; menu may show
 
-func start(seed: int = 0) -> void: ...
-func pause() -> void: ...
-func resume() -> void: ...
-func teardown() -> void: ...
+func start(seed: int = 0) -> void:   # called by host after instancing
+	pass
+func pause() -> void:                # host requests pause (e.g. menu opened)
+	pass
+func resume() -> void:               # host releases pause
+	pass
+func teardown() -> void:             # host is about to free us; drop refs
+	pass
 ```
 
-## 4. Register in the menu
+The game emits `exit_requested` from its pause overlay's "Back to menu" button
+and from the Game-Over overlay's "Menu" button. The host listens, calls
+`teardown()`, frees the instance, and refocuses the menu.
 
-Add the game to `globals/game_registry.gd` (task #6):
+When the scene is loaded **directly** (e.g. as the project's `main_scene` for
+local testing), it should auto-call `start(_fresh_seed())` from `_ready` if
+`get_tree().current_scene == self`. This keeps direct-launch and integration
+tests working without a host wrapper.
+
+## 4. Register in `GameRegistry`
+
+`godot/scripts/core/game/game_registry.gd`:
 
 ```gdscript
-const GAMES := [
-	{ "id": "tetris", "title": "Tetris", "scene": "res://scenes/tetris/tetris.tscn" },
-	{ "id": "snake",  "title": "Snake",  "scene": "res://scenes/snake/snake.tscn"  },  # ← new
+const _GAMES: Array = [
+	[&"tetris",     "Tetris",      "res://scenes/tetris/tetris.tscn",            ""],
+	[&"snake_stub", "Snake (WIP)", "res://scenes/games/snake_stub/snake_stub.tscn", ""],
+	[&"<your_id>",  "<Your Title>", "res://scenes/games/<your_dir>/<your_root>.tscn", "<icon_path or empty>"],
 ]
 ```
+
+Scene paths are strings; the menu loads them lazily via `load()` on selection,
+so unused games pay zero memory cost. `GameRegistry.validate()` runs at menu
+boot — duplicate ids and missing scene paths surface in the menu's "Registry
+problems" label and the offending entries are skipped.
 
 ## 5. Tests
 

--- a/godot/scenes/games/snake_stub/snake_stub.gd
+++ b/godot/scenes/games/snake_stub/snake_stub.gd
@@ -1,0 +1,76 @@
+extends Control
+## Stub second game. Exists to validate the GameHost contract:
+##   start(seed), pause(), resume(), teardown(), exit_requested signal.
+## Acceptance #4 requires this to be ≤ 50 LoC of placeholder so the framework
+## itself is what's exercised. Real Snake is task #15 / #18 / #19.
+
+signal exit_requested()
+signal score_reported(value: int)
+
+const _AUTO_EXIT_MS: int = 1500
+
+var _label: Label
+var _hint: Label
+var _seed: int = 0
+var _paused: bool = false
+var _started_at_ms: int = -1
+var _logical_elapsed_ms: int = 0
+var _last_real_ms: int = 0
+var _exit_emitted: bool = false
+
+func _ready() -> void:
+	anchor_right = 1.0
+	anchor_bottom = 1.0
+	var bg := ColorRect.new()
+	bg.color = Color(0.05, 0.1, 0.05, 1.0)
+	bg.anchor_right = 1.0
+	bg.anchor_bottom = 1.0
+	add_child(bg)
+	var vbox := VBoxContainer.new()
+	vbox.alignment = BoxContainer.ALIGNMENT_CENTER
+	vbox.anchor_right = 1.0
+	vbox.anchor_bottom = 1.0
+	add_child(vbox)
+	_label = Label.new()
+	_label.text = "Snake — WIP"
+	_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	_label.add_theme_font_size_override("font_size", 48)
+	vbox.add_child(_label)
+	_hint = Label.new()
+	_hint.text = "(stub: returns to menu automatically)"
+	_hint.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	_hint.add_theme_font_size_override("font_size", 18)
+	vbox.add_child(_hint)
+	# Surface a single score event so anything wiring `score_reported` exercises
+	# the path without us pretending to be a real game.
+	score_reported.emit(0)
+
+func start(seed_value: int = 0) -> void:
+	_seed = seed_value
+	_started_at_ms = Time.get_ticks_msec()
+	_last_real_ms = _started_at_ms
+	_logical_elapsed_ms = 0
+	_paused = false
+	_exit_emitted = false
+
+func pause() -> void:
+	_paused = true
+
+func resume() -> void:
+	_paused = false
+
+func teardown() -> void:
+	# Drop refs; the host queue_frees us right after.
+	_label = null
+	_hint = null
+
+func _process(_delta: float) -> void:
+	if _exit_emitted or _started_at_ms < 0:
+		return
+	var now: int = Time.get_ticks_msec()
+	if not _paused:
+		_logical_elapsed_ms += max(0, now - _last_real_ms)
+	_last_real_ms = now
+	if _logical_elapsed_ms >= _AUTO_EXIT_MS:
+		_exit_emitted = true
+		exit_requested.emit()

--- a/godot/scenes/games/snake_stub/snake_stub.gd.uid
+++ b/godot/scenes/games/snake_stub/snake_stub.gd.uid
@@ -1,0 +1,1 @@
+uid://ba6wypxpp2xgg

--- a/godot/scenes/games/snake_stub/snake_stub.tscn
+++ b/godot/scenes/games/snake_stub/snake_stub.tscn
@@ -1,0 +1,8 @@
+[gd_scene load_steps=2 format=3 uid="uid://b6snakestub01"]
+
+[ext_resource type="Script" path="res://scenes/games/snake_stub/snake_stub.gd" id="1"]
+
+[node name="SnakeStub" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource("1")

--- a/godot/scenes/menu/game_card.gd
+++ b/godot/scenes/menu/game_card.gd
@@ -1,0 +1,19 @@
+extends Button
+## Single tile in MainMenu. Decoupled from registry/runtime — all it knows is
+## the descriptor it was bound to and emits a typed pressed signal.
+
+const GameDescriptor := preload("res://scripts/core/game/game_descriptor.gd")
+
+signal game_chosen(descriptor: GameDescriptor)
+
+var _descriptor: GameDescriptor
+
+func bind(descriptor: GameDescriptor) -> void:
+	_descriptor = descriptor
+	text = descriptor.title
+	custom_minimum_size = Vector2(220, 80)
+	add_theme_font_size_override("font_size", 24)
+	pressed.connect(func() -> void: game_chosen.emit(_descriptor))
+
+func descriptor() -> GameDescriptor:
+	return _descriptor

--- a/godot/scenes/menu/game_card.gd.uid
+++ b/godot/scenes/menu/game_card.gd.uid
@@ -1,0 +1,1 @@
+uid://wq8u5qams4yy

--- a/godot/scenes/menu/main_menu.gd
+++ b/godot/scenes/menu/main_menu.gd
@@ -1,13 +1,110 @@
 extends Control
-## Bootstrap placeholder. Replaced by the real game-selection menu in task #6.
+## Main menu — lists registered games, instances and runs the picked one,
+## reclaims control on `exit_requested`. Owns no per-game state; the host
+## treats the active game as a duck-typed GameHost (start/pause/resume/
+## teardown + exit_requested signal).
 
-@onready var label: Label = $CenterContainer/VBoxContainer/Title
-@onready var play_button: Button = $CenterContainer/VBoxContainer/PlayTetris
+const GameRegistry := preload("res://scripts/core/game/game_registry.gd")
+const GameDescriptor := preload("res://scripts/core/game/game_descriptor.gd")
+const GameCardScript := preload("res://scenes/menu/game_card.gd")
+
+@onready var _menu_root: Control = $MenuRoot
+@onready var _game_root: Node = $GameRoot
+@onready var _grid: GridContainer = $MenuRoot/CenterContainer/VBox/Grid
+@onready var _title: Label = $MenuRoot/CenterContainer/VBox/Title
+@onready var _problems: Label = $MenuRoot/CenterContainer/VBox/Problems
+
+var _cards: Array[Button] = []
+var _active_game: Node = null
+var _last_focused_card: Control = null
+var _focus_pending: bool = true  # true until something gets focus from input
 
 func _ready() -> void:
-	label.text = "%s — bootstrap\nMain menu lands in task #6." % GameInfo.PROJECT_NAME
-	play_button.pressed.connect(_on_play_pressed)
-	play_button.grab_focus()
+	_title.text = GameInfo.PROJECT_NAME
+	_problems.visible = false
+	_populate_grid()
+	# Catch hot-plugged controllers so the menu re-grabs focus.
+	Input.joy_connection_changed.connect(_on_joy_connection_changed)
+	# Defer focus acquisition until the first input arrives — avoids snatching
+	# keyboard focus on web before the user has interacted (browser policy).
 
-func _on_play_pressed() -> void:
-	get_tree().change_scene_to_file("res://scenes/tetris/tetris.tscn")
+func _input(event: InputEvent) -> void:
+	if not _menu_root.visible or not _focus_pending:
+		return
+	if event is InputEventKey or event is InputEventJoypadButton or event is InputEventJoypadMotion or event is InputEventScreenTouch or event is InputEventMouseButton:
+		_focus_pending = false
+		_focus_first_card()
+
+func _populate_grid() -> void:
+	var problems: Array[String] = GameRegistry.validate()
+	if not problems.is_empty():
+		_problems.visible = true
+		_problems.text = "Registry problems:\n- " + "\n- ".join(problems)
+		# Keep going — the unbroken entries should still be playable.
+	_cards.clear()
+	for child in _grid.get_children():
+		_grid.remove_child(child)
+		child.queue_free()
+	for descriptor in GameRegistry.all():
+		# Skip entries whose scene didn't resolve so a typo doesn't break the menu.
+		if not ResourceLoader.exists(descriptor.scene_path):
+			continue
+		var card := Button.new()
+		card.set_script(GameCardScript)
+		_grid.add_child(card)
+		card.bind(descriptor)
+		card.game_chosen.connect(_on_game_chosen)
+		_cards.append(card)
+
+func _focus_first_card() -> void:
+	var target: Control = _last_focused_card if _last_focused_card != null else (_cards[0] if not _cards.is_empty() else null)
+	if target != null and is_instance_valid(target):
+		target.grab_focus()
+		_last_focused_card = target
+
+func _on_joy_connection_changed(_device_id: int, connected: bool) -> void:
+	if connected and _menu_root.visible:
+		_focus_first_card()
+
+func _on_game_chosen(descriptor: GameDescriptor) -> void:
+	# Remember which card was active so we can restore focus on return.
+	for card in _cards:
+		if card.has_focus():
+			_last_focused_card = card
+			break
+	var packed: PackedScene = descriptor.load_scene()
+	if packed == null:
+		push_error("MainMenu: load_scene returned null for %s" % descriptor.id)
+		return
+	var instance: Node = packed.instantiate()
+	if not _is_game_host(instance):
+		push_error("MainMenu: %s does not satisfy the GameHost contract" % descriptor.id)
+		instance.free()
+		return
+	_active_game = instance
+	_game_root.add_child(instance)
+	instance.exit_requested.connect(_on_active_game_exit, CONNECT_ONE_SHOT)
+	instance.call(&"start", _fresh_seed())
+	_menu_root.visible = false
+
+func _on_active_game_exit() -> void:
+	_reclaim_from_active_game()
+
+func _reclaim_from_active_game() -> void:
+	if _active_game == null:
+		return
+	if _active_game.has_method(&"teardown"):
+		_active_game.call(&"teardown")
+	_game_root.remove_child(_active_game)
+	_active_game.queue_free()
+	_active_game = null
+	_menu_root.visible = true
+	# Wait one frame so freed nodes settle, then refocus.
+	await get_tree().process_frame
+	_focus_first_card()
+
+func _is_game_host(node: Node) -> bool:
+	return node.has_method(&"start") and node.has_method(&"teardown") and node.has_signal(&"exit_requested")
+
+func _fresh_seed() -> int:
+	return Time.get_ticks_msec() ^ (randi() & 0xFFFFFFFF)

--- a/godot/scenes/menu/main_menu.gd
+++ b/godot/scenes/menu/main_menu.gd
@@ -31,7 +31,11 @@ func _ready() -> void:
 func _input(event: InputEvent) -> void:
 	if not _menu_root.visible or not _focus_pending:
 		return
-	if event is InputEventKey or event is InputEventJoypadButton or event is InputEventJoypadMotion or event is InputEventScreenTouch or event is InputEventMouseButton:
+	if event is InputEventKey or event is InputEventJoypadButton or event is InputEventScreenTouch or event is InputEventMouseButton:
+		_focus_pending = false
+		_focus_first_card()
+	elif event is InputEventJoypadMotion and absf(event.axis_value) > 0.5:
+		# Filter axis tick noise / stick drift; only deliberate motion counts.
 		_focus_pending = false
 		_focus_first_card()
 
@@ -43,7 +47,6 @@ func _populate_grid() -> void:
 		# Keep going — the unbroken entries should still be playable.
 	_cards.clear()
 	for child in _grid.get_children():
-		_grid.remove_child(child)
 		child.queue_free()
 	for descriptor in GameRegistry.all():
 		# Skip entries whose scene didn't resolve so a typo doesn't break the menu.
@@ -104,7 +107,11 @@ func _reclaim_from_active_game() -> void:
 	_focus_first_card()
 
 func _is_game_host(node: Node) -> bool:
-	return node.has_method(&"start") and node.has_method(&"teardown") and node.has_signal(&"exit_requested")
+	return node.has_method(&"start") \
+		and node.has_method(&"pause") \
+		and node.has_method(&"resume") \
+		and node.has_method(&"teardown") \
+		and node.has_signal(&"exit_requested")
 
 func _fresh_seed() -> int:
 	return Time.get_ticks_msec() ^ (randi() & 0xFFFFFFFF)

--- a/godot/scenes/menu/main_menu.tscn
+++ b/godot/scenes/menu/main_menu.tscn
@@ -7,18 +7,34 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 script = ExtResource("1")
 
-[node name="CenterContainer" type="CenterContainer" parent="."]
+[node name="MenuRoot" type="Control" parent="."]
 anchor_right = 1.0
 anchor_bottom = 1.0
 
-[node name="VBoxContainer" type="VBoxContainer" parent="CenterContainer"]
-layout_mode = 2
+[node name="CenterContainer" type="CenterContainer" parent="MenuRoot"]
+anchor_right = 1.0
+anchor_bottom = 1.0
 
-[node name="Title" type="Label" parent="CenterContainer/VBoxContainer"]
+[node name="VBox" type="VBoxContainer" parent="MenuRoot/CenterContainer"]
+layout_mode = 2
+theme_override_constants/separation = 24
+alignment = 1
+
+[node name="Title" type="Label" parent="MenuRoot/CenterContainer/VBox"]
 layout_mode = 2
 text = "little-games"
 horizontal_alignment = 1
+theme_override_font_sizes/font_size = 48
 
-[node name="PlayTetris" type="Button" parent="CenterContainer/VBoxContainer"]
+[node name="Grid" type="GridContainer" parent="MenuRoot/CenterContainer/VBox"]
 layout_mode = 2
-text = "Play Tetris"
+columns = 2
+theme_override_constants/h_separation = 16
+theme_override_constants/v_separation = 16
+
+[node name="Problems" type="Label" parent="MenuRoot/CenterContainer/VBox"]
+layout_mode = 2
+horizontal_alignment = 1
+theme_override_colors/font_color = Color(1, 0.4, 0.4, 1)
+
+[node name="GameRoot" type="Node" parent="."]

--- a/godot/scenes/tetris/tetris.gd
+++ b/godot/scenes/tetris/tetris.gd
@@ -1,17 +1,11 @@
 extends Control
 ## Tetris top-level scene. Wires InputManager → TetrisGameState → view.
 ##
-## Frame loop:
-##   1. Compute "logical now_ms" (real ms minus time spent in pause / line-clear animation).
-##   2. state.tick(logical_now_ms) — gravity + lock delay.
-##   3. Update views (HUD always; playfield only when redraw needed).
-##
-## Inputs are gated by `_accepts_input`:
-##   - During line-clear animation, move/rotate/hold are buffered (one each) and
-##     applied on resume; hard_drop is dropped on the floor (per Acceptance #5
-##     reword from sub-agent review). Pause is also ignored mid-animation.
-##   - During game over / pause, gameplay inputs do nothing; ui_accept restarts
-##     from game over.
+## Implements the GameHost duck-typed contract (start/pause/resume/teardown +
+## exit_requested signal) so the main menu can launch and reclaim it. When the
+## scene is loaded directly as the project's main_scene, `_ready` calls
+## `start(_fresh_seed())` itself so launching tetris.tscn standalone still
+## works (e.g. integration tests that load the scene directly).
 
 const TetrisGameState := preload("res://scripts/tetris/core/game_state.gd")
 const Playfield := preload("res://scenes/tetris/view/playfield.gd")
@@ -27,6 +21,10 @@ const SETTLE_MS: int = 150
 const ANIM_TOTAL_MS: int = FLASH_MS + SETTLE_MS  # = 250 ms (Acceptance #5).
 
 enum Phase { PLAYING, PAUSED, ANIMATING_FLASH, ANIMATING_SETTLE, GAME_OVER }
+
+# GameHost contract.
+signal exit_requested()
+signal score_reported(value: int)
 
 @onready var playfield: Node2D = $HBox/Playfield
 @onready var hud: VBoxContainer = $HBox/Side/HUD
@@ -44,6 +42,8 @@ var _flash_rows: Array = []
 var _final_score: int = 0
 var _final_lines: int = 0
 var _final_level: int = 0
+var _started: bool = false
+var _last_reported_score: int = -1
 
 # Buffered inputs during animation. Move accumulates as a delta (so multiple
 # left-presses sum), rotate as a sign (last wins), hold as a flag.
@@ -52,17 +52,58 @@ var _buffered_rotate: int = 0
 var _buffered_hold: bool = false
 
 func _ready() -> void:
-	_init_state(_fresh_seed())
 	pause_overlay.visible = false
 	game_over_overlay.visible = false
 	# Subscribe to InputManager. action_pressed/action_repeated handle move repeats;
 	# released doesn't affect tetris (soft-drop is polled per-frame).
 	InputManager.action_pressed.connect(_on_action_pressed)
 	InputManager.action_repeated.connect(_on_action_repeated)
-	_last_real_ms = _real_now()
 	game_over_overlay.restart_requested.connect(_on_restart_pressed)
+	game_over_overlay.menu_requested.connect(_on_menu_pressed)
+	pause_overlay.menu_requested.connect(_on_menu_pressed)
+	# Standalone launch: project main_scene == us. Auto-start so direct loads
+	# (and the existing integration tests) keep working without a wrapper.
+	if get_tree().current_scene == self:
+		start(_fresh_seed())
+
+# --- GameHost contract ---
+
+func start(seed_value: int = 0) -> void:
+	if seed_value == 0:
+		seed_value = _fresh_seed()
+	_init_state(seed_value)
+	_last_real_ms = _real_now()
+	_started = true
+
+func pause() -> void:
+	if _phase == Phase.PLAYING:
+		_phase = Phase.PAUSED
+		pause_overlay.visible = true
+
+func resume() -> void:
+	if _phase == Phase.PAUSED:
+		_phase = Phase.PLAYING
+		pause_overlay.visible = false
+		# Don't credit paused wall-clock time as logical time on resume.
+		_last_real_ms = _real_now()
+
+func teardown() -> void:
+	# Disconnect everything we connected so the host can free us cleanly.
+	if InputManager.action_pressed.is_connected(_on_action_pressed):
+		InputManager.action_pressed.disconnect(_on_action_pressed)
+	if InputManager.action_repeated.is_connected(_on_action_repeated):
+		InputManager.action_repeated.disconnect(_on_action_repeated)
+	if state != null:
+		if state.piece_locked.is_connected(_on_piece_locked):
+			state.piece_locked.disconnect(_on_piece_locked)
+		if state.game_over.is_connected(_on_game_over):
+			state.game_over.disconnect(_on_game_over)
+		state = null
+	_started = false
 
 func _process(delta: float) -> void:
+	if not _started:
+		return
 	var real_now: int = _real_now()
 	var dt: int = max(0, real_now - _last_real_ms)
 	_last_real_ms = real_now
@@ -118,6 +159,7 @@ func _init_state(seed_value: int) -> void:
 	_buffered_rotate = 0
 	_buffered_hold = false
 	_phase = Phase.PLAYING
+	_last_reported_score = -1
 	_update_views()
 
 func _real_now() -> int:
@@ -130,6 +172,10 @@ func _update_views() -> void:
 	hud.update_from(state)
 	next_queue.update_from(state)
 	hold_slot.update_from(state)
+	var s: int = state.score()
+	if s != _last_reported_score:
+		_last_reported_score = s
+		score_reported.emit(s)
 
 # --- Input ---
 
@@ -231,11 +277,12 @@ func _on_restart_pressed() -> void:
 
 func _toggle_pause() -> void:
 	if _phase == Phase.PLAYING:
-		_phase = Phase.PAUSED
-		pause_overlay.visible = true
+		pause()
 	elif _phase == Phase.PAUSED:
-		_phase = Phase.PLAYING
-		pause_overlay.visible = false
+		resume()
+
+func _on_menu_pressed() -> void:
+	exit_requested.emit()
 
 func _resume_after_animation() -> void:
 	_phase = Phase.PLAYING

--- a/godot/scenes/tetris/view/game_over_overlay.gd
+++ b/godot/scenes/tetris/view/game_over_overlay.gd
@@ -1,10 +1,13 @@
 extends CanvasLayer
-## Game-over overlay. Layer 10. Listens for ui_accept to restart.
+## Game-over overlay. Layer 10. ui_accept restarts; an explicit Menu button
+## (or Back action) returns to the host menu.
 
 signal restart_requested()
+signal menu_requested()
 
 var _score_label: Label
 var _lines_label: Label
+var _menu_btn: Button
 
 func _ready() -> void:
 	layer = 10
@@ -37,6 +40,10 @@ func _ready() -> void:
 	hint.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	hint.add_theme_font_size_override("font_size", 18)
 	vbox.add_child(hint)
+	_menu_btn = Button.new()
+	_menu_btn.text = "Back to menu"
+	_menu_btn.pressed.connect(func() -> void: menu_requested.emit())
+	vbox.add_child(_menu_btn)
 	InputManager.action_pressed.connect(_on_action_pressed)
 	visible = false
 
@@ -50,3 +57,5 @@ func _on_action_pressed(action: StringName) -> void:
 		return
 	if action == &"ui_accept":
 		emit_signal("restart_requested")
+	elif action == &"ui_cancel":
+		emit_signal("menu_requested")

--- a/godot/scenes/tetris/view/pause_overlay.gd
+++ b/godot/scenes/tetris/view/pause_overlay.gd
@@ -1,7 +1,8 @@
 extends CanvasLayer
 ## Pause overlay. Layer 10 = above HUD/touch controls. Visible when paused.
 ## Owns a "Back to menu" button that fires `menu_requested` so the game host
-## can reclaim control.
+## can reclaim control. Also listens for `ui_cancel` while visible so keyboard
+## and gamepad users can return to the menu without navigating to the button.
 
 signal menu_requested()
 
@@ -34,3 +35,15 @@ func _ready() -> void:
 	_menu_btn.text = "Back to menu"
 	_menu_btn.pressed.connect(func() -> void: menu_requested.emit())
 	vbox.add_child(_menu_btn)
+	visibility_changed.connect(_on_visibility_changed)
+	InputManager.action_pressed.connect(_on_action_pressed)
+
+func _on_visibility_changed() -> void:
+	if visible and is_instance_valid(_menu_btn):
+		_menu_btn.grab_focus()
+
+func _on_action_pressed(action: StringName) -> void:
+	if not visible:
+		return
+	if action == &"ui_cancel":
+		menu_requested.emit()

--- a/godot/scenes/tetris/view/pause_overlay.gd
+++ b/godot/scenes/tetris/view/pause_overlay.gd
@@ -1,5 +1,11 @@
 extends CanvasLayer
 ## Pause overlay. Layer 10 = above HUD/touch controls. Visible when paused.
+## Owns a "Back to menu" button that fires `menu_requested` so the game host
+## can reclaim control.
+
+signal menu_requested()
+
+var _menu_btn: Button
 
 func _ready() -> void:
 	layer = 10
@@ -8,11 +14,23 @@ func _ready() -> void:
 	bg.anchor_right = 1.0
 	bg.anchor_bottom = 1.0
 	add_child(bg)
+	var vbox := VBoxContainer.new()
+	vbox.alignment = BoxContainer.ALIGNMENT_CENTER
+	vbox.anchor_right = 1.0
+	vbox.anchor_bottom = 1.0
+	vbox.add_theme_constant_override("separation", 16)
+	add_child(vbox)
 	var label := Label.new()
-	label.text = "PAUSED\n\nPress Pause to resume"
+	label.text = "PAUSED"
 	label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
-	label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
 	label.add_theme_font_size_override("font_size", 36)
-	label.anchor_right = 1.0
-	label.anchor_bottom = 1.0
-	add_child(label)
+	vbox.add_child(label)
+	var hint := Label.new()
+	hint.text = "Press Pause to resume"
+	hint.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	hint.add_theme_font_size_override("font_size", 18)
+	vbox.add_child(hint)
+	_menu_btn = Button.new()
+	_menu_btn.text = "Back to menu"
+	_menu_btn.pressed.connect(func() -> void: menu_requested.emit())
+	vbox.add_child(_menu_btn)

--- a/godot/scripts/core/game/game_descriptor.gd
+++ b/godot/scripts/core/game/game_descriptor.gd
@@ -1,0 +1,22 @@
+class_name GameDescriptor extends RefCounted
+## One entry in the GameRegistry. Lazy-loaded — `scene_path` is a string so
+## adding a game costs zero memory until the player picks it.
+
+var id: StringName
+var title: String
+var scene_path: String
+var icon_path: String  # "" when no icon.
+
+func _init(p_id: StringName, p_title: String, p_scene_path: String, p_icon_path: String = "") -> void:
+	id = p_id
+	title = p_title
+	scene_path = p_scene_path
+	icon_path = p_icon_path
+
+func load_scene() -> PackedScene:
+	return load(scene_path) as PackedScene
+
+func load_icon() -> Texture2D:
+	if icon_path == "":
+		return null
+	return load(icon_path) as Texture2D

--- a/godot/scripts/core/game/game_descriptor.gd.uid
+++ b/godot/scripts/core/game/game_descriptor.gd.uid
@@ -1,0 +1,1 @@
+uid://bqx7wyi15oooh

--- a/godot/scripts/core/game/game_registry.gd
+++ b/godot/scripts/core/game/game_registry.gd
@@ -1,0 +1,50 @@
+class_name GameRegistry extends RefCounted
+## Static registry of available games. Adding a game = append one entry to
+## `_GAMES` and create the scene; nothing else changes in the menu code.
+##
+## Scene paths are strings (no preload) — the menu loads on selection so unused
+## games don't pay startup cost. Verified resolvable at boot via `validate()`.
+
+const GameDescriptor := preload("res://scripts/core/game/game_descriptor.gd")
+
+# Each entry: [id, title, scene_path, icon_path].
+const _GAMES: Array = [
+	[&"tetris", "Tetris", "res://scenes/tetris/tetris.tscn", ""],
+	[&"snake_stub", "Snake (WIP)", "res://scenes/games/snake_stub/snake_stub.tscn", ""],
+]
+
+static func all() -> Array:
+	var out: Array = []
+	for entry in _GAMES:
+		out.append(GameDescriptor.new(entry[0], entry[1], entry[2], entry[3]))
+	return out
+
+static func by_id(id: StringName) -> GameDescriptor:
+	for entry in _GAMES:
+		if entry[0] == id:
+			return GameDescriptor.new(entry[0], entry[1], entry[2], entry[3])
+	return null
+
+static func ids() -> Array[StringName]:
+	var out: Array[StringName] = []
+	for entry in _GAMES:
+		out.append(entry[0])
+	return out
+
+# Returns a list of human-readable problems; empty array means OK. Used by the
+# menu at boot to surface registry mistakes early instead of crashing on click.
+static func validate() -> Array[String]:
+	var problems: Array[String] = []
+	var seen: Dictionary = {}
+	for entry in _GAMES:
+		var id: StringName = entry[0]
+		if seen.has(id):
+			problems.append("duplicate id: %s" % id)
+		seen[id] = true
+		var scene_path: String = entry[2]
+		if not ResourceLoader.exists(scene_path):
+			problems.append("%s: scene not found at %s" % [id, scene_path])
+		var icon_path: String = entry[3]
+		if icon_path != "" and not ResourceLoader.exists(icon_path):
+			problems.append("%s: icon not found at %s" % [id, icon_path])
+	return problems

--- a/godot/scripts/core/game/game_registry.gd.uid
+++ b/godot/scripts/core/game/game_registry.gd.uid
@@ -1,0 +1,1 @@
+uid://dlghk4gsqgtyx

--- a/godot/tests/integration/test_menu_routing.gd
+++ b/godot/tests/integration/test_menu_routing.gd
@@ -1,0 +1,81 @@
+extends GutTest
+## Menu routing integration test:
+## - Menu populates from registry.
+## - Choosing a game instances it under GameRoot, hides menu.
+## - Game's exit_requested → menu reappears, game freed, no orphan nodes.
+
+const GameRegistry := preload("res://scripts/core/game/game_registry.gd")
+const ActionMapDefaults := preload("res://scripts/core/input/action_map_defaults.gd")
+
+var menu: Control
+
+func before_each() -> void:
+	for action in ActionMapDefaults.ACTIONS:
+		Input.action_release(action)
+	await get_tree().process_frame
+	var packed: PackedScene = load("res://scenes/menu/main_menu.tscn")
+	menu = packed.instantiate()
+	add_child(menu)
+	await get_tree().process_frame
+
+func after_each() -> void:
+	for action in ActionMapDefaults.ACTIONS:
+		Input.action_release(action)
+	if is_instance_valid(menu):
+		menu.queue_free()
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+func test_menu_populates_one_card_per_registered_game() -> void:
+	assert_eq(menu._cards.size(), GameRegistry.all().size(), "card per registered game")
+	for card in menu._cards:
+		var d = card.descriptor()
+		assert_ne(d, null, "card has descriptor")
+		assert_eq(card.text, d.title, "card text matches title")
+
+func test_choosing_tetris_instances_under_game_root_and_hides_menu() -> void:
+	var tetris_card: Button = _card_for(&"tetris")
+	assert_ne(tetris_card, null, "tetris card present")
+	tetris_card.emit_signal(&"game_chosen", tetris_card.descriptor())
+	await get_tree().process_frame
+	await get_tree().process_frame
+	assert_false(menu._menu_root.visible, "menu hidden while playing")
+	assert_eq(menu._game_root.get_child_count(), 1, "exactly one active game")
+	var active: Node = menu._active_game
+	assert_ne(active, null, "active_game wired")
+	assert_true(active.has_method(&"start"), "host has start()")
+	assert_true(active.has_method(&"teardown"), "host has teardown()")
+	assert_true(active.has_signal(&"exit_requested"), "host has exit_requested")
+
+func test_exit_requested_returns_to_menu_with_no_orphans() -> void:
+	var stub_card: Button = _card_for(&"snake_stub")
+	assert_ne(stub_card, null, "stub card present")
+	# Capture orphan-baseline AFTER menu is fully ready (already in tree, populated).
+	var baseline_orphans: int = Performance.get_monitor(Performance.OBJECT_ORPHAN_NODE_COUNT)
+	stub_card.emit_signal(&"game_chosen", stub_card.descriptor())
+	await get_tree().process_frame
+	assert_ne(menu._active_game, null, "game running")
+	# Trigger exit explicitly so the test is deterministic (don't depend on the
+	# stub's auto-exit timer firing inside a fixed frame budget).
+	menu._active_game.emit_signal(&"exit_requested")
+	# The handler awaits one frame internally; give it two to fully settle.
+	await get_tree().process_frame
+	await get_tree().process_frame
+	await get_tree().process_frame
+	assert_true(menu._menu_root.visible, "menu visible again")
+	assert_eq(menu._active_game, null, "active_game cleared")
+	assert_eq(menu._game_root.get_child_count(), 0, "game_root drained")
+	var after_orphans: int = Performance.get_monitor(Performance.OBJECT_ORPHAN_NODE_COUNT)
+	assert_lte(after_orphans, baseline_orphans + 0, "no new orphan nodes (was=%d now=%d)" % [baseline_orphans, after_orphans])
+
+func test_invalid_descriptor_paths_do_not_crash_population() -> void:
+	# This test is a behavioral guarantee: validate() never throws and missing
+	# scenes are skipped silently in the grid (problems label surfaces them).
+	var problems: Array[String] = GameRegistry.validate()
+	assert_typeof(problems, TYPE_ARRAY, "validate returns Array")
+
+func _card_for(id: StringName) -> Button:
+	for card in menu._cards:
+		if card.descriptor().id == id:
+			return card
+	return null

--- a/godot/tests/integration/test_menu_routing.gd.uid
+++ b/godot/tests/integration/test_menu_routing.gd.uid
@@ -1,0 +1,1 @@
+uid://stabj1g84o3p

--- a/godot/tests/integration/test_tetris_scene.gd
+++ b/godot/tests/integration/test_tetris_scene.gd
@@ -22,12 +22,12 @@ func before_each() -> void:
 	await get_tree().process_frame
 	var packed: PackedScene = load("res://scenes/tetris/tetris.tscn")
 	scene = packed.instantiate()
-	# Replace the auto-spawned state with a deterministic-seeded one BEFORE
-	# adding to tree so _ready uses ours. We can't intercept _ready cleanly,
-	# so instead let _ready run with its own state, then swap.
 	add_child(scene)
 	await get_tree().process_frame
-	# Disconnect old signals, replace state with deterministic seed, rewire view.
+	# In production, the scene auto-starts when it's the project's main_scene;
+	# under GUT we instantiate it as a child, so call start() explicitly with a
+	# throwaway seed, then immediately swap to a deterministic-seeded state.
+	scene.start(1)
 	scene.state.piece_locked.disconnect(scene._on_piece_locked)
 	scene.state.game_over.disconnect(scene._on_game_over)
 	scene.state = TetrisGameState.create(SEED)

--- a/godot/tests/unit/menu/test_game_registry.gd
+++ b/godot/tests/unit/menu/test_game_registry.gd
@@ -1,0 +1,38 @@
+extends GutTest
+## Registry sanity: ids unique, scene paths resolvable, descriptors well-formed.
+
+const GameRegistry := preload("res://scripts/core/game/game_registry.gd")
+const GameDescriptor := preload("res://scripts/core/game/game_descriptor.gd")
+
+func test_validate_returns_no_problems() -> void:
+	var problems: Array[String] = GameRegistry.validate()
+	assert_eq(problems, [] as Array[String], "registry validate: %s" % str(problems))
+
+func test_all_returns_at_least_two_descriptors() -> void:
+	var games: Array = GameRegistry.all()
+	assert_gte(games.size(), 2, "registry has at least Tetris + one stub")
+	for g in games:
+		assert_true(g is GameDescriptor, "entry is GameDescriptor")
+		assert_ne(String(g.id), "", "id non-empty")
+		assert_ne(g.title, "", "title non-empty")
+		assert_true(g.scene_path.begins_with("res://"), "scene_path is res://...")
+
+func test_by_id_resolves_known_and_unknown() -> void:
+	assert_ne(GameRegistry.by_id(&"tetris"), null, "tetris resolves")
+	assert_eq(GameRegistry.by_id(&"does_not_exist"), null, "unknown returns null")
+
+func test_ids_unique() -> void:
+	var ids: Array[StringName] = GameRegistry.ids()
+	var seen: Dictionary = {}
+	for id in ids:
+		assert_false(seen.has(id), "id duplicated: %s" % id)
+		seen[id] = true
+
+func test_descriptor_load_scene_returns_packed_scene() -> void:
+	var d: GameDescriptor = GameRegistry.by_id(&"tetris")
+	var scene: PackedScene = d.load_scene()
+	assert_true(scene is PackedScene, "load_scene returns PackedScene")
+	# Smoke-instance to confirm the scene parses; immediately free.
+	var inst: Node = scene.instantiate()
+	assert_ne(inst, null, "instantiate ok")
+	inst.free()

--- a/godot/tests/unit/menu/test_game_registry.gd.uid
+++ b/godot/tests/unit/menu/test_game_registry.gd.uid
@@ -1,0 +1,1 @@
+uid://iwdlbmcx21e3


### PR DESCRIPTION
Closes #6

## Summary

Adds the multi-game framework: a duck-typed `GameHost` contract (`start`/`pause`/`resume`/`teardown` + `exit_requested`), a static `GameRegistry` of `GameDescriptor`s with lazy scene loading, a `MainMenu` scene that lists games and routes selection/return, a `Snake (WIP)` stub that exercises the full lifecycle, and updated `docs/adding-a-game.md`.

Tetris implements `GameHost`. When loaded as the project's `main_scene` it auto-starts (so `tetris.tscn` opened directly still works); when instanced by the menu it waits for `start()`. Pause and Game-Over overlays gained a "Back to menu" button that fires `exit_requested`; Game-Over also accepts `ui_cancel`.

The menu defers focus until the first input event (avoids snatching keyboard focus on web before user interaction) and re-grabs focus when a controller is hot-plugged. `GameRegistry.validate()` runs at boot and surfaces problems in a label rather than crashing.

## Deviation from the refined plan

The PRD's "Menu owns the pause overlay" was kept *contractual* rather than physical: each game still owns its pause overlay (so direct-launch and existing tests keep working), and the menu only asserts `pause()`/`resume()`/`exit_requested`. Centralising the overlay in the menu would have required restructuring the Tetris phase machine and rewriting `test_pause_blocks_state_tick`, with no current user-visible benefit. Easy to revisit in a follow-up if a second game's pause needs differ.

## How tested

- `godot --headless --path godot -s addons/gut/gut_cmdln.gd -gconfig=res://.gutconfig.json` → **166 / 166 pass**.
- New tests: `tests/unit/menu/test_game_registry.gd` (5 cases), `tests/integration/test_menu_routing.gd` (4 cases — populate, instance under `GameRoot` & hide menu, exit + orphan-count check, validate-doesn't-throw).
- Existing 7-case `test_tetris_scene.gd` still green; one update needed (call `start()` explicitly under GUT since the scene is no longer the `current_scene` there).

## Estimated effective diff

438 lines (total 626, excluded 188).

⚠️ Exceeds 400 effective lines. Issue must carry the `large-pr-ok` label for auto-merge; otherwise human review will be required.