### PR TITLE
docs: persistence + snapshot contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,7 @@ Conventional-ish: `feat: …`, `fix: …`, `test: …`, `chore: …`, `docs: …
 - GDScript, **statically typed** (`var x: int`, `-> void`).
 - Tabs (Godot default).
 - Per-game `core/` must not import `Node` or call OS/Engine APIs. This is the testability contract.
-- Per-game `core/` exposes state via `snapshot() -> Dictionary` (with `version: int`); never via signals. Scenes diff snapshots. See `docs/persistence.md` for the persistence key namespace and schema policy.
+- Per-game `core/` exposes evolving state via `snapshot() -> Dictionary`; scenes diff snapshots between ticks. Signals reserved for one-shot events (e.g. `piece_locked`, `game_over`). New cores SHOULD include `version: int` in the snapshot. See `docs/persistence.md` and `docs/architecture.md` § "Snapshot diffs, not signals".
 
 ### Tests — three layers, all required
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,7 @@ Conventional-ish: `feat: …`, `fix: …`, `test: …`, `chore: …`, `docs: …
 - GDScript, **statically typed** (`var x: int`, `-> void`).
 - Tabs (Godot default).
 - Per-game `core/` must not import `Node` or call OS/Engine APIs. This is the testability contract.
+- Per-game `core/` exposes state via `snapshot() -> Dictionary` (with `version: int`); never via signals. Scenes diff snapshots. See `docs/persistence.md` for the persistence key namespace and schema policy.
 
 ### Tests — three layers, all required
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,6 +39,16 @@ Godot wins on the pareto frontier for "small classic games on every platform wit
 
 The hard rule: **per-game `core/` must not import `Node` or anything Godot-specific** (only `Resource`, primitives, math). This keeps the game rules independently testable and portable should we ever swap the rendering layer.
 
+## Snapshot diffs, not signals
+
+Per-game `core/` exposes mutations via `snapshot()` returning a `Dictionary` with at least a `version: int` field plus game-specific state. Scenes detect what changed by **diffing successive snapshots between ticks** — never by subscribing to signals. Reasons:
+
+- Cores stay `Node`-free (the testability contract above).
+- Replay/integration tests can drive a core deterministically and assert on snapshots without a render layer attached.
+- One uniform mechanism replaces ad-hoc per-event callbacks.
+
+See `docs/persistence.md` for the canonical key namespace and schema-mismatch policy that builds on this contract.
+
 ## Directory map
 
 See `CLAUDE.md` §3.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,11 +41,13 @@ The hard rule: **per-game `core/` must not import `Node` or anything Godot-speci
 
 ## Snapshot diffs, not signals
 
-Per-game `core/` exposes mutations via `snapshot()` returning a `Dictionary` with at least a `version: int` field plus game-specific state. Scenes detect what changed by **diffing successive snapshots between ticks** — never by subscribing to signals. Reasons:
+Per-game `core/` exposes its evolving state via `snapshot()` returning a `Dictionary` (new cores SHOULD include a `version: int` field — see `docs/persistence.md`). Scenes detect what changed by **diffing successive snapshots between ticks** rather than subscribing to per-state-bit signals. Reasons:
 
 - Cores stay `Node`-free (the testability contract above).
 - Replay/integration tests can drive a core deterministically and assert on snapshots without a render layer attached.
 - One uniform mechanism replaces ad-hoc per-event callbacks.
+
+**Exception — one-shot events.** Cores MAY expose Godot `signal`s for *discrete events* that aren't usefully captured by snapshot diffs (e.g. `piece_locked` carrying line-clear metadata, `game_over` carrying a reason code). These are fire-and-forget notifications, never used to communicate ongoing state. The tetris core (`scripts/tetris/core/game_state.gd`) uses both mechanisms: snapshot for the board/piece state, signals for `piece_locked` / `game_over`. The general rule: if the scene needs to *react* to a one-shot moment (SFX, screen-shake, modal), a signal is fine; if it needs to *render* a value, that value goes in the snapshot.
 
 See `docs/persistence.md` for the canonical key namespace and schema-mismatch policy that builds on this contract.
 

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -18,7 +18,7 @@ Keys are dotted paths. Per-game keys are prefixed with the game's `id` (also use
 | `input.das_ms`           | `int`          | #5a                | Delayed-Auto-Shift, ms |
 | `input.arr_ms`           | `int`          | #5a                | Auto-Repeat-Rate, ms |
 | `input.binding.<action>.<slot>` | `Dictionary` | #5b          | rebind slot — `<slot> ∈ {kbd, pad}` |
-| `tetris.best`            | `int`          | #5a                | replaces `tetris.high_score` |
+| `tetris.high_score`      | `int`          | bootstrap          | live key in `globals/settings.gd`; rename to `tetris.best` is a backlog cleanup |
 | `snake.best.<difficulty>` | `int`         | snake-polish (#19) | `<difficulty> ∈ {easy, normal, hard}` |
 | `g2048.best`             | `int`          | 2048-polish (#21)  | 4×4 only in v1 |
 | `breakout.best.level_NN` | `int`          | breakout-polish (#23) | per-level high score |
@@ -28,17 +28,17 @@ Game IDs are intentionally **not** the project name (`2048` would lead with a di
 
 ## Snapshot schema
 
-Every per-game `core/`'s `snapshot()` returns a Godot `Dictionary` with at least:
+Every per-game `core/`'s `snapshot()` returns a Godot `Dictionary`. New cores **SHOULD** include:
 
 - `version: int` — schema version. Bumped on **breaking** changes (renamed/removed fields, changed semantics). Adding a new optional field that the scene tolerates is *not* breaking.
 - … game-specific fields (board, pieces, score, etc.).
+
+The existing tetris core (`scripts/tetris/core/game_state.gd`) does **not** yet include `version`; it'll be added in #35 (its own polish PR), at which point this section will move from SHOULD to MUST. Until then, persistence code that round-trips a snapshot must defensively treat a missing `version` as the implicit version `0`.
 
 This is the canonical wire format between core ↔ scene ↔ persistence:
 
 - The **scene** consumes `snapshot()` to render. It diffs successive snapshots between ticks to detect what changed (see `docs/architecture.md` § "Snapshot diffs, not signals").
 - **Persistence** writes a snapshot subset (typically `version` + a high-score field) under the namespaced key.
-
-Cores **never** emit Godot signals. They are pure GDScript with no `Node` dependency — see `CLAUDE.md` § "Code style".
 
 ## Schema-mismatch policy
 

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -1,0 +1,61 @@
+# Persistence
+
+The contract for *user-visible* persistence (settings, high scores, per-game state) across all games in this repo. Everything written to `user://` flows through `Settings.set_value` / `get_value` (defined in #5a). This file documents the **key namespace** and the **schema-mismatch policy**.
+
+> **Out of scope:** non-game persistence (window size, telemetry, achievements). Add a section here if/when those land.
+
+## Key namespace
+
+Keys are dotted paths. Per-game keys are prefixed with the game's `id` (also used by `GameInfo` and the menu): `tetris`, `snake`, `g2048`, `breakout`. Cross-game settings have no prefix.
+
+`level_NN` is **two-digit zero-padded** (`level_01` … `level_99`). New games append rows to the table; **every polish PR for a new game must update this file**.
+
+| Key | Type | Owner | Notes |
+|---|---|---|---|
+| `audio.master`           | `float` 0..1   | #5a                | master volume |
+| `audio.sfx`              | `float` 0..1   | #5a                | SFX bus volume |
+| `audio.music`            | `float` 0..1   | #5a                | music bus volume |
+| `input.das_ms`           | `int`          | #5a                | Delayed-Auto-Shift, ms |
+| `input.arr_ms`           | `int`          | #5a                | Auto-Repeat-Rate, ms |
+| `input.binding.<action>.<slot>` | `Dictionary` | #5b          | rebind slot — `<slot> ∈ {kbd, pad}` |
+| `tetris.best`            | `int`          | #5a                | replaces `tetris.high_score` |
+| `snake.best.<difficulty>` | `int`         | snake-polish (#19) | `<difficulty> ∈ {easy, normal, hard}` |
+| `g2048.best`             | `int`          | 2048-polish (#21)  | 4×4 only in v1 |
+| `breakout.best.level_NN` | `int`          | breakout-polish (#23) | per-level high score |
+| `breakout.best.run`      | `int`          | breakout-polish (#23) | best score across the full level pack |
+
+Game IDs are intentionally **not** the project name (`2048` would lead with a digit and is awkward to use as a key prefix); the canonical id is `g2048`.
+
+## Snapshot schema
+
+Every per-game `core/`'s `snapshot()` returns a Godot `Dictionary` with at least:
+
+- `version: int` — schema version. Bumped on **breaking** changes (renamed/removed fields, changed semantics). Adding a new optional field that the scene tolerates is *not* breaking.
+- … game-specific fields (board, pieces, score, etc.).
+
+This is the canonical wire format between core ↔ scene ↔ persistence:
+
+- The **scene** consumes `snapshot()` to render. It diffs successive snapshots between ticks to detect what changed (see `docs/architecture.md` § "Snapshot diffs, not signals").
+- **Persistence** writes a snapshot subset (typically `version` + a high-score field) under the namespaced key.
+
+Cores **never** emit Godot signals. They are pure GDScript with no `Node` dependency — see `CLAUDE.md` § "Code style".
+
+## Schema-mismatch policy
+
+When loading a stored value (high score or saved game) whose embedded `version` is **older than the current code's version** AND no migration is registered for that step:
+
+1. **Wipe** the offending key (treat as if absent).
+2. **Toast** the user once: *"Saved data was from an older version and has been reset."*
+3. Continue from the default value (e.g. `0` for `*.best`).
+
+This is consistent with the #5b decision: prefer brutal correctness over silent data corruption. Migrations are only written for transitions where carrying old data forward has user value (e.g. a high score). The toast is shown at most once per session.
+
+A `version` **newer** than the code's current version is the same situation in reverse — happens when a user downgrades. Same handling: wipe + toast.
+
+## Adding a new persistence key — checklist
+
+When a new game's polish PR lands, or when a cross-game setting is added:
+
+1. Append the row to the table above (key, type, owner, notes).
+2. If the key holds a structured value (not a primitive), bump the schema version and document the new field shape in the relevant `core/`.
+3. Reference this file from the issue's PRD so reviewers can confirm the namespace is honored.


### PR DESCRIPTION
Closes #14

Doc-only PR. Adds `docs/persistence.md` (canonical persistence key namespace + schema-mismatch policy), promotes the snapshot-diff-not-signals rule to a first-class subsection in `docs/architecture.md`, and adds a one-line restatement under `CLAUDE.md` §5.

Pre-declares high-score keys for tetris / snake / g2048 / breakout so the upcoming polish PRs (#19 / #21 / #23) don't relitigate the schema in code review.

## How tested
- Doc-only — no `.gd` files modified.
- Sanity: GUT pass locally in worktree (167/167).

## Estimated effective diff
0 lines (total 72, excluded 72 — all under `docs/` or top-level `.md`).