### PR TITLE
fix(tetris): cold-load class_name race + layout + CI guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,21 @@ jobs:
             -s addons/gut/gut_cmdln.gd \
             -gconfig=res://.gutconfig.json
 
+      - name: Cold-load smoke (subprocess, not GUT)
+        run: |
+          # Run in a fresh process so the global class table is empty —
+          # reproduces what a user hits on a real cold launch from the menu.
+          # GUT pre-compiles every test file at suite start, which warms the
+          # class table and hides the bug in #33. Belt-and-suspenders: check
+          # both exit code and stderr for SCRIPT ERROR (Godot can print
+          # compile errors without setting non-zero exit).
+          godot --headless --path godot --script res://tests/cold_load_smoke.gd 2> stderr.log
+          if grep -q "SCRIPT ERROR" stderr.log; then
+            cat stderr.log
+            echo "::error::SCRIPT ERROR detected during cold-load"
+            exit 1
+          fi
+
   export-web:
     name: Export Web (Pages)
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,13 @@ jobs:
       - name: Verify Godot
         run: godot --version
 
+      - name: Lint — no class_name in per-game core/
+        run: |
+          if grep -rn '^class_name ' godot/scripts/*/core/; then
+            echo "::error::per-game core/ scripts must not declare class_name (see issue #33)"
+            exit 1
+          fi
+
       - name: Import project (populates .godot cache)
         run: |
           # `--import` exits non-zero on harmless reimport messages on some

--- a/docs/adding-a-game.md
+++ b/docs/adding-a-game.md
@@ -24,6 +24,45 @@ godot/
     └── test_*.gd
 ```
 
+### `core/` cross-references — `preload`, never `class_name`
+
+Per-game `core/` scripts **must not** declare `class_name`. Use `const`
+preloads instead — for siblings AND for self-references inside static
+factories:
+
+```gdscript
+# scripts/<game>/core/state.gd
+extends RefCounted
+
+const Self := preload("res://scripts/<game>/core/state.gd")
+const Board := preload("res://scripts/<game>/core/board.gd")
+
+static func create(seed: int) -> Self:
+    var g: Self = Self.new()
+    g.board = Board.new()
+    return g
+```
+
+Reason: games are lazy-loaded from the menu via `descriptor.load_scene()`.
+The global `class_name` table is consulted before the script's own
+`class_name` registers, so any self-typed reference like
+`static func create() -> MyClass` fails to resolve on a cold launch and
+the whole core fails to compile. `preload` is a direct script reference
+that doesn't depend on the global table. CI enforces:
+
+```yaml
+- name: Lint — no class_name in per-game core/
+  run: |
+    if grep -rn '^class_name ' godot/scripts/*/core/; then
+      echo "::error::per-game core/ scripts must not declare class_name"
+      exit 1
+    fi
+```
+
+Shared infra under `scripts/core/` (e.g. `GameDescriptor`,
+`GameRegistry`, `DasArr`) is exempt — it isn't lazy-loaded and the
+register-on-startup pattern works fine there.
+
 ## 3. Implement the GameHost contract
 
 The menu launches a game by instancing its root scene and calling lifecycle

--- a/godot/scenes/tetris/tetris.gd
+++ b/godot/scenes/tetris/tetris.gd
@@ -26,7 +26,7 @@ enum Phase { PLAYING, PAUSED, ANIMATING_FLASH, ANIMATING_SETTLE, GAME_OVER }
 signal exit_requested()
 signal score_reported(value: int)
 
-@onready var playfield: Node2D = $HBox/Playfield
+@onready var playfield: Node2D = $HBox/PlayfieldHost/Playfield
 @onready var hud: VBoxContainer = $HBox/Side/HUD
 @onready var next_queue: VBoxContainer = $HBox/Side/NextQueue
 @onready var hold_slot: Control = $HBox/Side/HoldSlot

--- a/godot/scenes/tetris/tetris.tscn
+++ b/godot/scenes/tetris/tetris.tscn
@@ -27,7 +27,10 @@ offset_bottom = 300.0
 alignment = 1
 theme_override_constants/separation = 16
 
-[node name="Playfield" type="Node2D" parent="HBox"]
+[node name="PlayfieldHost" type="Control" parent="HBox"]
+custom_minimum_size = Vector2(288, 568)
+
+[node name="Playfield" type="Node2D" parent="HBox/PlayfieldHost"]
 script = ExtResource("2_pf")
 
 [node name="Side" type="VBoxContainer" parent="HBox"]

--- a/godot/scripts/tetris/core/bag.gd
+++ b/godot/scripts/tetris/core/bag.gd
@@ -1,4 +1,3 @@
-class_name TetrisBag
 extends RefCounted
 ## 7-bag (random generator). Pure: no Engine, no global RNG.
 ##
@@ -6,13 +5,14 @@ extends RefCounted
 ## {I,O,T,S,Z,J,L}. After 7 pulls a new permutation is generated. Same seed
 ## always produces the same sequence. Use `peek(n)` for the Next preview.
 
+const Self := preload("res://scripts/tetris/core/bag.gd")
 const PieceKind := preload("res://scripts/tetris/core/piece_kind.gd")
 
 var _rng: RandomNumberGenerator
 var _bag: Array  # holds upcoming kinds in pull order; refilled when empty
 
-static func create(bag_seed: int) -> TetrisBag:
-	var b: TetrisBag = TetrisBag.new()
+static func create(bag_seed: int) -> Self:
+	var b: Self = Self.new()
 	b._init_seed(bag_seed)
 	return b
 

--- a/godot/scripts/tetris/core/board.gd
+++ b/godot/scripts/tetris/core/board.gd
@@ -1,4 +1,3 @@
-class_name TetrisBoard
 extends RefCounted
 ## 10x40 playfield grid (cols 0..9, rows 0..39). Pure data + queries.
 ##

--- a/godot/scripts/tetris/core/game_state.gd
+++ b/godot/scripts/tetris/core/game_state.gd
@@ -1,4 +1,3 @@
-class_name TetrisGameState
 extends RefCounted
 ## The pure Tetris controller: composes Board, Bag, Scoring, T-spin into a
 ## tickable rule machine. No Node, no Engine, no autoloads — caller drives
@@ -8,6 +7,7 @@ extends RefCounted
 ## reproduces the same snapshot exactly — that's the property #7 (integration
 ## tests) relies on.
 
+const Self := preload("res://scripts/tetris/core/game_state.gd")
 const PieceKind := preload("res://scripts/tetris/core/piece_kind.gd")
 const Piece := preload("res://scripts/tetris/core/piece.gd")
 const Board := preload("res://scripts/tetris/core/board.gd")
@@ -49,8 +49,8 @@ var _is_grounded: bool = false
 var _lock_ms_owed: int = 0
 var _lock_resets: int = 0
 
-static func create(game_seed: int) -> TetrisGameState:
-	var g: TetrisGameState = TetrisGameState.new()
+static func create(game_seed: int) -> Self:
+	var g: Self = Self.new()
 	g.board = Board.new()
 	g.bag = Bag.create(game_seed)
 	g.scoring = Scoring.new()

--- a/godot/scripts/tetris/core/kicks.gd
+++ b/godot/scripts/tetris/core/kicks.gd
@@ -1,4 +1,3 @@
-class_name TetrisKicks
 extends RefCounted
 ## SRS wall-kick offset tables. Pure data — no Node, no Engine.
 ##

--- a/godot/scripts/tetris/core/levels.gd
+++ b/godot/scripts/tetris/core/levels.gd
@@ -1,4 +1,3 @@
-class_name TetrisLevels
 extends RefCounted
 ## Gravity ms-per-row by level (Tetris Worlds curve, the most-cited Guideline
 ## reference). Pure data. Levels >= MAX_LEVEL are clamped to the fastest tier.

--- a/godot/scripts/tetris/core/piece.gd
+++ b/godot/scripts/tetris/core/piece.gd
@@ -1,23 +1,23 @@
-class_name TetrisPiece
 extends RefCounted
 ## Live tetromino state: kind + origin (col, row in 10x40 board space) + rotation.
 ## Pure value object. Rendering is a downstream concern.
 
+const Self := preload("res://scripts/tetris/core/piece.gd")
 const PieceKind := preload("res://scripts/tetris/core/piece_kind.gd")
 
 var kind: int = PieceKind.Kind.I
 var origin: Vector2i = Vector2i.ZERO
 var rot: int = PieceKind.Rot.ZERO
 
-static func spawn(kind_id: int) -> TetrisPiece:
-	var p: TetrisPiece = TetrisPiece.new()
+static func spawn(kind_id: int) -> Self:
+	var p: Self = Self.new()
 	p.kind = kind_id
 	p.origin = Vector2i(PieceKind.SPAWN_COLS[kind_id], PieceKind.SPAWN_ROW)
 	p.rot = PieceKind.Rot.ZERO
 	return p
 
-func clone() -> TetrisPiece:
-	var p: TetrisPiece = TetrisPiece.new()
+func clone() -> Self:
+	var p: Self = Self.new()
 	p.kind = kind
 	p.origin = origin
 	p.rot = rot

--- a/godot/scripts/tetris/core/piece_kind.gd
+++ b/godot/scripts/tetris/core/piece_kind.gd
@@ -1,4 +1,3 @@
-class_name TetrisPieceKind
 extends RefCounted
 ## SRS piece kinds and per-rotation cell layouts. Pure data — no Node, no Engine.
 ##

--- a/godot/scripts/tetris/core/scoring.gd
+++ b/godot/scripts/tetris/core/scoring.gd
@@ -1,4 +1,3 @@
-class_name TetrisScoring
 extends RefCounted
 ## Tetris Guideline scoring: per-clear base, B2B (1.5x for difficult clears),
 ## combo bonus, and soft/hard-drop helpers. Pure stateful object — no Engine.

--- a/godot/scripts/tetris/core/t_spin.gd
+++ b/godot/scripts/tetris/core/t_spin.gd
@@ -1,4 +1,3 @@
-class_name TetrisTSpin
 extends RefCounted
 ## T-spin classification, isolated for testability.
 ##

--- a/godot/tests/cold_load_smoke.gd
+++ b/godot/tests/cold_load_smoke.gd
@@ -1,0 +1,36 @@
+extends SceneTree
+## Cold-load smoke test. Invoked via `--script` in a fresh Godot subprocess
+## (NOT inside GUT) so the global script class table is empty at start —
+## reproducing what users hit on a real cold launch from the main menu.
+##
+## For each game in GameRegistry, instantiate the root scene and verify it
+## satisfies the GameHost duck-typed contract. Exit code = problem count;
+## CI also greps stderr for `SCRIPT ERROR` because Godot may print
+## compile errors without setting a non-zero exit.
+
+const GameRegistry := preload("res://scripts/core/game/game_registry.gd")
+
+func _initialize() -> void:
+	var problems: Array[String] = []
+	for descriptor in GameRegistry.all():
+		var packed: PackedScene = descriptor.load_scene()
+		if packed == null:
+			problems.append("%s: load_scene returned null" % descriptor.id)
+			continue
+		var instance: Node = packed.instantiate()
+		if instance == null:
+			problems.append("%s: instantiate returned null" % descriptor.id)
+			continue
+		for m in [&"start", &"pause", &"resume", &"teardown"]:
+			if not instance.has_method(m):
+				problems.append("%s: missing method %s" % [descriptor.id, m])
+		if not instance.has_signal(&"exit_requested"):
+			problems.append("%s: missing signal exit_requested" % descriptor.id)
+		instance.free()
+	if problems.is_empty():
+		print("[cold_load_smoke] OK")
+		quit(0)
+	else:
+		for p in problems:
+			push_error("[cold_load_smoke] %s" % p)
+		quit(problems.size())

--- a/godot/tests/integration/test_game_host_contract.gd
+++ b/godot/tests/integration/test_game_host_contract.gd
@@ -1,0 +1,25 @@
+extends GutTest
+## Forward-looking shape check: every registered game's scene satisfies the
+## GameHost duck-typed contract (start/pause/resume/teardown methods +
+## exit_requested signal). Catches contract drift (e.g. a new game forgets
+## `pause`) within the warm GUT environment.
+##
+## NOT a substitute for tests/cold_load_smoke.gd — that runs in a subprocess
+## to catch class_name / preload race bugs that only manifest cold.
+
+const GameRegistry := preload("res://scripts/core/game/game_registry.gd")
+
+func test_every_registered_game_satisfies_game_host_contract() -> void:
+	for descriptor in GameRegistry.all():
+		var packed: PackedScene = descriptor.load_scene()
+		assert_ne(packed, null, "%s: load_scene returned null" % descriptor.id)
+		if packed == null:
+			continue
+		var inst: Node = packed.instantiate()
+		assert_ne(inst, null, "%s: instantiate returned null" % descriptor.id)
+		if inst == null:
+			continue
+		for m in [&"start", &"pause", &"resume", &"teardown"]:
+			assert_true(inst.has_method(m), "%s missing method %s" % [descriptor.id, m])
+		assert_true(inst.has_signal(&"exit_requested"), "%s missing signal exit_requested" % descriptor.id)
+		inst.free()


### PR DESCRIPTION
Closes #33

## What

Tetris fails to compile on a cold launch from the main menu (post-#31). Root cause: per-game `core/` scripts use `class_name TetrisX` *and* self-type their static factories (`static func create() -> TetrisX`). When a game is lazy-loaded, the global class table is consulted before the script's own `class_name` registers — the self-references fail to resolve, compilation cascades, the scene never instantiates. GUT hides this because it pre-compiles every test file at suite start, warming the table.

## How fixed

1. **`refactor(tetris/core)`** — drop `class_name TetrisX` from all 9 `scripts/tetris/core/*.gd` files. Self-typed factories (`bag`, `piece`, `game_state`) now use `const Self := preload("…/this_file.gd")` and reference `Self`. Sibling references already used `preload` and are unchanged. Outside callers (`tetris.gd`, integration tests) already alias the cores via their own `const TetrisGameState := preload(...)` so removing the global name doesn't affect them.
2. **`fix(tetris/scene)`** — wrap the `Playfield` `Node2D` in a sized `Control` parent (`PlayfieldHost`, `custom_minimum_size = 288×568`). `HBoxContainer` only lays out `Control` children, so the bare `Node2D` contributed 0×0 and HUD shifted while the playfield drew at an unrelated absolute position. Update `@onready` path in `tetris.gd`.
3. **`ci: lint`** — add a CI grep that fails on `^class_name ` under `godot/scripts/*/core/`. Excludes `scripts/core/` (shared infra, allowed).
4. **`ci: cold-load smoke`** — new `godot/tests/cold_load_smoke.gd` invoked via `--script` in a fresh subprocess (NOT GUT). Iterates `GameRegistry.all()`, instantiates each scene, asserts the GameHost duck-type. CI checks both exit code and stderr for `SCRIPT ERROR`.
5. **`test(integration)`** — new `tests/integration/test_game_host_contract.gd` catches *shape* drift inside GUT; complements (4) which catches cold-load races.
6. **`docs(adding-a-game)`** — document the rule + the lint.

## Commit order is bisectable

Commits 1–3 (lint, cold-load, contract test) land **before** the refactor. Each guardrail is observably red on its own — lint hits 9 violations, cold-load reports the same `Identifier not found: TetrisGameState` users see — and the refactor commit (4) turns them green. Commits 5–6 are the layout fix and docs. CI run on each commit will demonstrate this.

## How tested

- GUT pass locally in worktree: 168/168 tests, 1714 asserts, 8.7s.
- New `tests/integration/test_game_host_contract.gd` passes — both `tetris` and `snake_stub` satisfy the contract.
- Cold-load smoke (`godot --headless --script res://tests/cold_load_smoke.gd`) exits 0 with empty stderr.
- Verified `^class_name ` no longer matches under `godot/scripts/*/core/`.
- Verified no `is Tetris* / as Tetris*` survives anywhere.
- External callers (`scenes/tetris/tetris.gd`, `tests/integration/test_tetris_scene.gd`, `tests/integration/test_full_session.gd`, `tests/unit/tetris/test_game_state.gd`) all already alias core scripts via local `const X := preload(...)` so they keep compiling.

## Local-dev note

Removing `class_name` invalidates `godot/.godot/global_script_class_cache.cfg`. On `main` after merge, delete `.godot/` (or open the project in the editor once) to drop stale `Identifier not found` errors against the old cache. CI runs against a fresh checkout so this is local-only.

## Estimated effective diff

57 lines (total 157, excluded 100 — tests + docs + workflow YAML).
