### PR TITLE
feat(breakout): scene + paddle/ball/brick rendering + integration tests

### DIFF
--- a/godot/scenes/breakout/breakout.gd
+++ b/godot/scenes/breakout/breakout.gd
@@ -1,0 +1,331 @@
+extends Control
+## Breakout top-level scene. Wires InputManager → BreakoutGameState → world view.
+##
+## Implements the GameHost duck-typed contract (start/pause/resume/teardown +
+## exit_requested / score_reported signals). Mirrors scenes/snake/snake.gd
+## and scenes/g2048/g2048.gd structure.
+##
+## Render model: world.gd draws in world-units (config.world_w × world_h);
+## this scene applies a uniform fit-letterbox transform to the BoardHost
+## Control on every viewport resize.
+
+const BreakoutConfig := preload("res://scripts/breakout/core/breakout_config.gd")
+const BreakoutLevel := preload("res://scripts/breakout/core/breakout_level.gd")
+const BreakoutGameState := preload("res://scripts/breakout/core/breakout_state.gd")
+const World := preload("res://scenes/breakout/view/world.gd")
+const HUD := preload("res://scenes/breakout/view/hud.gd")
+const PauseOverlay := preload("res://scenes/breakout/view/pause_overlay.gd")
+const LifeLostOverlay := preload("res://scenes/breakout/view/life_lost_overlay.gd")
+const GameOverOverlay := preload("res://scenes/breakout/view/game_over_overlay.gd")
+const WinOverlay := preload("res://scenes/breakout/view/win_overlay.gd")
+
+const DEFAULT_LEVEL_PATH: String = "res://scenes/breakout/levels/level_01.tres"
+
+# GameHost contract.
+signal exit_requested()
+signal score_reported(value: int)
+
+const SWIPE_MIN_PX_LAUNCH_ZONE: float = 24.0
+const LIFE_LOST_OVERLAY_MS: int = 800
+
+enum Phase { PLAYING, PAUSED, LIFE_LOST, GAME_OVER, WON }
+
+@onready var board_host: Control = $HBox/BoardHost
+@onready var world: Node2D = $HBox/BoardHost/World
+@onready var hud: VBoxContainer = $HBox/Side/HUD
+@onready var pause_overlay: CanvasLayer = $PauseOverlay
+@onready var life_lost_overlay: CanvasLayer = $LifeLostOverlay
+@onready var game_over_overlay: CanvasLayer = $GameOverOverlay
+@onready var win_overlay: CanvasLayer = $WinOverlay
+
+var state: BreakoutGameState
+var config: BreakoutConfig
+var level: BreakoutLevel
+var _phase: int = Phase.PLAYING
+var _logical_now_ms: int = 0
+var _last_real_ms: int = 0
+var _started: bool = false
+var _last_reported_score: int = -1
+var _seed: int = 0
+var _level_index: int = 1
+var _life_lost_until_ms: int = -1
+var _last_lives: int = -1
+
+# Touch tracking. Drag = paddle target; quick tap on lower 25% = launch.
+var _touch_index: int = -1
+var _touch_start: Vector2 = Vector2.ZERO
+var _touch_world_target_x: float = -1.0   # world-coord paddle target; -1 = none
+
+# Cached letterbox transform.
+var _world_to_local_scale: float = 1.0
+var _world_to_local_offset: Vector2 = Vector2.ZERO
+
+func _ready() -> void:
+	pause_overlay.visible = false
+	life_lost_overlay.visible = false
+	game_over_overlay.visible = false
+	win_overlay.visible = false
+	InputManager.action_pressed.connect(_on_action_pressed)
+	game_over_overlay.restart_requested.connect(_on_restart_pressed)
+	game_over_overlay.menu_requested.connect(_on_menu_pressed)
+	pause_overlay.menu_requested.connect(_on_menu_pressed)
+	win_overlay.restart_requested.connect(_on_restart_pressed)
+	win_overlay.menu_requested.connect(_on_menu_pressed)
+	board_host.resized.connect(_recompute_letterbox)
+	# Standalone launch: auto-start with deterministic seed 0.
+	if get_tree().current_scene == self:
+		start(0)
+
+# --- GameHost contract ---
+
+func start(seed_value: int = 0) -> void:
+	_seed = seed_value
+	config = BreakoutConfig.new()
+	level = load(DEFAULT_LEVEL_PATH) as BreakoutLevel
+	if level == null:
+		push_error("Breakout: failed to load %s" % DEFAULT_LEVEL_PATH)
+		return
+	state = BreakoutGameState.create(_seed, config, level)
+	world.configure(config.world_w, config.world_h, config.ball_radius, _build_brick_meta())
+	_phase = Phase.PLAYING
+	_logical_now_ms = 0
+	_last_real_ms = _real_now()
+	_last_reported_score = -1
+	_last_lives = -1
+	_life_lost_until_ms = -1
+	_touch_index = -1
+	_touch_world_target_x = -1.0
+	pause_overlay.visible = false
+	life_lost_overlay.visible = false
+	game_over_overlay.visible = false
+	win_overlay.visible = false
+	_started = true
+	_recompute_letterbox()
+	_update_views()
+
+func pause() -> void:
+	if _phase == Phase.PLAYING or _phase == Phase.LIFE_LOST:
+		_phase = Phase.PAUSED if _phase == Phase.PLAYING else Phase.PAUSED
+		pause_overlay.visible = true
+
+func resume() -> void:
+	if _phase == Phase.PAUSED:
+		_phase = Phase.PLAYING
+		pause_overlay.visible = false
+		_last_real_ms = _real_now()
+
+func teardown() -> void:
+	if InputManager.action_pressed.is_connected(_on_action_pressed):
+		InputManager.action_pressed.disconnect(_on_action_pressed)
+	state = null
+	config = null
+	level = null
+	_started = false
+
+# --- Loop ---
+
+func _process(_delta: float) -> void:
+	if not _started or state == null:
+		return
+	var real_now: int = _real_now()
+	var dt: int = max(0, real_now - _last_real_ms)
+	_last_real_ms = real_now
+	if _phase == Phase.PAUSED or _phase == Phase.GAME_OVER or _phase == Phase.WON:
+		return
+	_logical_now_ms += dt
+	# Compute paddle intent each frame from input. Touch target overrides
+	# digital/analog if active.
+	state.set_paddle_intent(_compute_paddle_intent_px_s(dt))
+	var changed: bool = state.tick(_logical_now_ms)
+	if changed:
+		_update_views()
+	# Mode transitions.
+	if state.is_won() and _phase != Phase.WON:
+		_enter_won()
+		return
+	if state.is_game_over() and _phase != Phase.GAME_OVER:
+		_enter_game_over()
+		return
+	# Life-lost overlay timeout.
+	if _phase == Phase.LIFE_LOST and _logical_now_ms >= _life_lost_until_ms:
+		_phase = Phase.PLAYING
+		life_lost_overlay.visible = false
+
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_APPLICATION_FOCUS_IN:
+		_last_real_ms = _real_now()
+
+# --- Paddle intent ---
+
+func _compute_paddle_intent_px_s(dt_ms: int) -> float:
+	# Touch drag: lerp paddle x toward finger target with max speed.
+	if _touch_world_target_x >= 0.0 and state != null:
+		var dx: float = _touch_world_target_x - state.paddle_x
+		if absf(dx) < 0.5:
+			return 0.0
+		# Convert "want to move dx px in dt_ms ms" to px/s, clamped at apply.
+		var seconds: float = maxf(float(dt_ms) / 1000.0, 0.001)
+		return clampf(dx / seconds, -config.paddle_max_speed_px_s, config.paddle_max_speed_px_s)
+	# Digital + analog: action-strength delta.
+	var right: float = Input.get_action_strength(&"move_right")
+	var left: float = Input.get_action_strength(&"move_left")
+	var axis: float = clampf(right - left, -1.0, 1.0)
+	return axis * config.paddle_max_speed_px_s
+
+# --- View ---
+
+func _update_views() -> void:
+	if state == null:
+		return
+	var snap: Dictionary = state.snapshot()
+	world.update_from_snapshot(snap)
+	hud.update_from_snapshot(snap, _level_index)
+	# Detect life loss → trigger life-lost overlay.
+	var lives: int = int(snap.get("lives", 0))
+	if _last_lives >= 0 and lives < _last_lives and lives > 0 and int(snap.get("mode", -1)) == BreakoutGameState.Mode.STICKY:
+		_phase = Phase.LIFE_LOST
+		life_lost_overlay.set_lives(lives)
+		life_lost_overlay.visible = true
+		_life_lost_until_ms = _logical_now_ms + LIFE_LOST_OVERLAY_MS
+	_last_lives = lives
+	var s: int = int(snap.get("score", 0))
+	if s != _last_reported_score:
+		_last_reported_score = s
+		score_reported.emit(s)
+
+func _build_brick_meta() -> Dictionary:
+	# Mirror BreakoutGameState._expand_level_to_bricks logic so the renderer
+	# can resolve idx → {cx, cy, hx, hy, color_id, destructible}. Snapshot
+	# only carries idx + hp; this static metadata stays constant per level.
+	var out: Dictionary = {}
+	if level == null:
+		return out
+	var hx: float = level.brick_w * 0.5
+	var hy: float = level.brick_h * 0.5
+	var n: int = level.cells.size()
+	for i in n:
+		var cell: Variant = level.cells[i]
+		if not (cell is Dictionary):
+			continue
+		var d: Dictionary = cell
+		var hp: int = int(d.get("hp", 0))
+		if hp <= 0:
+			continue
+		var col: int = i % level.cols
+		var row: int = i / level.cols
+		var cx: float = level.origin_x + col * level.brick_w + hx
+		var cy: float = level.origin_y + row * level.brick_h + hy
+		out[i] = {
+			"cx": cx, "cy": cy, "hx": hx, "hy": hy,
+			"color_id": int(d.get("color_id", 0)),
+			"destructible": bool(d.get("destructible", true)),
+		}
+	return out
+
+# --- Letterbox ---
+
+func _recompute_letterbox() -> void:
+	if config == null:
+		return
+	var avail: Vector2 = board_host.size
+	if avail.x <= 0.0 or avail.y <= 0.0:
+		return
+	var sx: float = avail.x / config.world_w
+	var sy: float = avail.y / config.world_h
+	var s: float = minf(sx, sy)
+	var used: Vector2 = Vector2(config.world_w, config.world_h) * s
+	var off: Vector2 = (avail - used) * 0.5
+	_world_to_local_scale = s
+	_world_to_local_offset = off
+	if world != null:
+		world.position = off
+		world.scale = Vector2(s, s)
+
+func _local_to_world(local: Vector2) -> Vector2:
+	if _world_to_local_scale <= 0.0:
+		return Vector2.ZERO
+	return (local - _world_to_local_offset) / _world_to_local_scale
+
+# --- Input: action signals ---
+
+func _on_action_pressed(action: StringName) -> void:
+	if action == &"pause":
+		_toggle_pause()
+		return
+	if _phase != Phase.PLAYING and _phase != Phase.LIFE_LOST:
+		return
+	if state == null:
+		return
+	if action == &"hard_drop":
+		state.launch()
+
+# --- Input: touch ---
+
+func _unhandled_input(event: InputEvent) -> void:
+	if event is InputEventScreenTouch:
+		_handle_touch(event as InputEventScreenTouch)
+	elif event is InputEventScreenDrag:
+		_handle_drag(event as InputEventScreenDrag)
+
+func _handle_touch(t: InputEventScreenTouch) -> void:
+	if _phase != Phase.PLAYING and _phase != Phase.LIFE_LOST:
+		return
+	if t.pressed:
+		if _touch_index == -1:
+			_touch_index = t.index
+			_touch_start = t.position
+			# Set initial paddle target from touch position.
+			var w: Vector2 = _local_to_world(board_host.get_local_mouse_position())
+			# board_host's local mouse position isn't reliable for synthetic events;
+			# convert from touch global instead.
+			w = _local_to_world(board_host.to_local(t.position))
+			_touch_world_target_x = clampf(w.x, 0.0, config.world_w)
+	else:
+		if t.index == _touch_index:
+			# Tap = small movement and on lower 25% triggers launch.
+			var delta: Vector2 = t.position - _touch_start
+			if delta.length() < SWIPE_MIN_PX_LAUNCH_ZONE:
+				var w: Vector2 = _local_to_world(board_host.to_local(t.position))
+				if w.y >= config.world_h * 0.75 and state != null:
+					state.launch()
+			_touch_index = -1
+			_touch_world_target_x = -1.0
+
+func _handle_drag(d: InputEventScreenDrag) -> void:
+	if d.index != _touch_index:
+		return
+	if _phase != Phase.PLAYING and _phase != Phase.LIFE_LOST:
+		return
+	var w: Vector2 = _local_to_world(board_host.to_local(d.position))
+	_touch_world_target_x = clampf(w.x, 0.0, config.world_w)
+
+# --- Phase transitions ---
+
+func _toggle_pause() -> void:
+	if _phase == Phase.PLAYING or _phase == Phase.LIFE_LOST:
+		pause()
+	elif _phase == Phase.PAUSED:
+		resume()
+
+func _enter_game_over() -> void:
+	_phase = Phase.GAME_OVER
+	life_lost_overlay.visible = false
+	var snap: Dictionary = state.snapshot()
+	game_over_overlay.show_with(int(snap.get("score", 0)))
+
+func _enter_won() -> void:
+	_phase = Phase.WON
+	life_lost_overlay.visible = false
+	var snap: Dictionary = state.snapshot()
+	win_overlay.show_with(int(snap.get("score", 0)))
+
+func _on_restart_pressed() -> void:
+	game_over_overlay.visible = false
+	win_overlay.visible = false
+	start(_seed + 1)
+
+func _on_menu_pressed() -> void:
+	exit_requested.emit()
+
+func _real_now() -> int:
+	return Time.get_ticks_msec()

--- a/godot/scenes/breakout/breakout.gd.uid
+++ b/godot/scenes/breakout/breakout.gd.uid
@@ -1,0 +1,1 @@
+uid://bvirdeaytbm2g

--- a/godot/scenes/breakout/breakout.tscn
+++ b/godot/scenes/breakout/breakout.tscn
@@ -1,0 +1,53 @@
+[gd_scene load_steps=8 format=3 uid="uid://bbreakroot01"]
+
+[ext_resource type="Script" path="res://scenes/breakout/breakout.gd" id="1_root"]
+[ext_resource type="Script" path="res://scenes/breakout/view/world.gd" id="2_world"]
+[ext_resource type="Script" path="res://scenes/breakout/view/hud.gd" id="3_hud"]
+[ext_resource type="Script" path="res://scenes/breakout/view/pause_overlay.gd" id="4_pause"]
+[ext_resource type="Script" path="res://scenes/breakout/view/life_lost_overlay.gd" id="5_life"]
+[ext_resource type="Script" path="res://scenes/breakout/view/game_over_overlay.gd" id="6_over"]
+[ext_resource type="Script" path="res://scenes/breakout/view/win_overlay.gd" id="7_win"]
+
+[node name="Breakout" type="Control"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource("1_root")
+
+[node name="HBox" type="HBoxContainer" parent="."]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -300.0
+offset_top = -200.0
+offset_right = 300.0
+offset_bottom = 200.0
+alignment = 1
+theme_override_constants/separation = 16
+
+[node name="BoardHost" type="Control" parent="HBox"]
+custom_minimum_size = Vector2(420, 320)
+
+[node name="World" type="Node2D" parent="HBox/BoardHost"]
+script = ExtResource("2_world")
+
+[node name="Side" type="VBoxContainer" parent="HBox"]
+custom_minimum_size = Vector2(140, 0)
+theme_override_constants/separation = 16
+
+[node name="HUD" type="VBoxContainer" parent="HBox/Side"]
+script = ExtResource("3_hud")
+
+[node name="PauseOverlay" type="CanvasLayer" parent="."]
+script = ExtResource("4_pause")
+
+[node name="LifeLostOverlay" type="CanvasLayer" parent="."]
+script = ExtResource("5_life")
+
+[node name="GameOverOverlay" type="CanvasLayer" parent="."]
+script = ExtResource("6_over")
+
+[node name="WinOverlay" type="CanvasLayer" parent="."]
+script = ExtResource("7_win")

--- a/godot/scenes/breakout/levels/level_01.tres
+++ b/godot/scenes/breakout/levels/level_01.tres
@@ -1,0 +1,74 @@
+[gd_resource type="Resource" script_class="" load_steps=2 format=3 uid="uid://bbreaklv01"]
+
+[ext_resource type="Script" path="res://scripts/breakout/core/breakout_level.gd" id="1_lvl"]
+
+[resource]
+script = ExtResource("1_lvl")
+rows = 6
+cols = 10
+brick_w = 28.0
+brick_h = 10.0
+origin_x = 20.0
+origin_y = 20.0
+cells = [
+{"hp": 1, "value": 100, "destructible": true, "color_id": 0},
+{"hp": 1, "value": 100, "destructible": true, "color_id": 0},
+{"hp": 1, "value": 100, "destructible": true, "color_id": 0},
+{"hp": 1, "value": 100, "destructible": true, "color_id": 0},
+{"hp": 1, "value": 100, "destructible": true, "color_id": 0},
+{"hp": 1, "value": 100, "destructible": true, "color_id": 0},
+{"hp": 1, "value": 100, "destructible": true, "color_id": 0},
+{"hp": 1, "value": 100, "destructible": true, "color_id": 0},
+{"hp": 1, "value": 100, "destructible": true, "color_id": 0},
+{"hp": 1, "value": 100, "destructible": true, "color_id": 0},
+{"hp": 1, "value": 90, "destructible": true, "color_id": 1},
+{"hp": 1, "value": 90, "destructible": true, "color_id": 1},
+{"hp": 1, "value": 90, "destructible": true, "color_id": 1},
+{"hp": 1, "value": 90, "destructible": true, "color_id": 1},
+{"hp": 1, "value": 90, "destructible": true, "color_id": 1},
+{"hp": 1, "value": 90, "destructible": true, "color_id": 1},
+{"hp": 1, "value": 90, "destructible": true, "color_id": 1},
+{"hp": 1, "value": 90, "destructible": true, "color_id": 1},
+{"hp": 1, "value": 90, "destructible": true, "color_id": 1},
+{"hp": 1, "value": 90, "destructible": true, "color_id": 1},
+{"hp": 1, "value": 70, "destructible": true, "color_id": 2},
+{"hp": 1, "value": 70, "destructible": true, "color_id": 2},
+{"hp": 1, "value": 70, "destructible": true, "color_id": 2},
+{"hp": 1, "value": 70, "destructible": true, "color_id": 2},
+{"hp": 1, "value": 70, "destructible": true, "color_id": 2},
+{"hp": 1, "value": 70, "destructible": true, "color_id": 2},
+{"hp": 1, "value": 70, "destructible": true, "color_id": 2},
+{"hp": 1, "value": 70, "destructible": true, "color_id": 2},
+{"hp": 1, "value": 70, "destructible": true, "color_id": 2},
+{"hp": 1, "value": 70, "destructible": true, "color_id": 2},
+{"hp": 1, "value": 50, "destructible": true, "color_id": 3},
+{"hp": 1, "value": 50, "destructible": true, "color_id": 3},
+{"hp": 1, "value": 50, "destructible": true, "color_id": 3},
+{"hp": 1, "value": 50, "destructible": true, "color_id": 3},
+{"hp": 1, "value": 50, "destructible": true, "color_id": 3},
+{"hp": 1, "value": 50, "destructible": true, "color_id": 3},
+{"hp": 1, "value": 50, "destructible": true, "color_id": 3},
+{"hp": 1, "value": 50, "destructible": true, "color_id": 3},
+{"hp": 1, "value": 50, "destructible": true, "color_id": 3},
+{"hp": 1, "value": 50, "destructible": true, "color_id": 3},
+{"hp": 1, "value": 30, "destructible": true, "color_id": 4},
+{"hp": 1, "value": 30, "destructible": true, "color_id": 4},
+{"hp": 1, "value": 30, "destructible": true, "color_id": 4},
+{"hp": 1, "value": 30, "destructible": true, "color_id": 4},
+{"hp": 1, "value": 30, "destructible": true, "color_id": 4},
+{"hp": 1, "value": 30, "destructible": true, "color_id": 4},
+{"hp": 1, "value": 30, "destructible": true, "color_id": 4},
+{"hp": 1, "value": 30, "destructible": true, "color_id": 4},
+{"hp": 1, "value": 30, "destructible": true, "color_id": 4},
+{"hp": 1, "value": 30, "destructible": true, "color_id": 4},
+{"hp": 1, "value": 20, "destructible": true, "color_id": 5},
+{"hp": 1, "value": 20, "destructible": true, "color_id": 5},
+{"hp": 1, "value": 20, "destructible": true, "color_id": 5},
+{"hp": 1, "value": 20, "destructible": true, "color_id": 5},
+{"hp": 1, "value": 20, "destructible": true, "color_id": 5},
+{"hp": 1, "value": 20, "destructible": true, "color_id": 5},
+{"hp": 1, "value": 20, "destructible": true, "color_id": 5},
+{"hp": 1, "value": 20, "destructible": true, "color_id": 5},
+{"hp": 1, "value": 20, "destructible": true, "color_id": 5},
+{"hp": 1, "value": 20, "destructible": true, "color_id": 5},
+]

--- a/godot/scenes/breakout/view/game_over_overlay.gd
+++ b/godot/scenes/breakout/view/game_over_overlay.gd
@@ -1,0 +1,54 @@
+extends CanvasLayer
+## Game-over overlay. Layer 10. ui_accept retries; ui_cancel returns to menu.
+
+signal restart_requested()
+signal menu_requested()
+
+var _score_label: Label
+var _menu_btn: Button
+
+func _ready() -> void:
+	layer = 10
+	var bg := ColorRect.new()
+	bg.color = Color(0, 0, 0, 0.7)
+	bg.anchor_right = 1.0
+	bg.anchor_bottom = 1.0
+	add_child(bg)
+	var vbox := VBoxContainer.new()
+	vbox.alignment = BoxContainer.ALIGNMENT_CENTER
+	vbox.anchor_right = 1.0
+	vbox.anchor_bottom = 1.0
+	vbox.add_theme_constant_override("separation", 16)
+	add_child(vbox)
+	var title := Label.new()
+	title.text = "GAME OVER"
+	title.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	title.add_theme_font_size_override("font_size", 48)
+	vbox.add_child(title)
+	_score_label = Label.new()
+	_score_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	_score_label.add_theme_font_size_override("font_size", 24)
+	vbox.add_child(_score_label)
+	var hint := Label.new()
+	hint.text = "Press Confirm to retry"
+	hint.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	hint.add_theme_font_size_override("font_size", 18)
+	vbox.add_child(hint)
+	_menu_btn = Button.new()
+	_menu_btn.text = "Back to menu"
+	_menu_btn.pressed.connect(func() -> void: menu_requested.emit())
+	vbox.add_child(_menu_btn)
+	InputManager.action_pressed.connect(_on_action_pressed)
+	visible = false
+
+func show_with(score: int) -> void:
+	_score_label.text = "Final Score: %d" % score
+	visible = true
+
+func _on_action_pressed(action: StringName) -> void:
+	if not visible:
+		return
+	if action == &"ui_accept":
+		restart_requested.emit()
+	elif action == &"ui_cancel":
+		menu_requested.emit()

--- a/godot/scenes/breakout/view/game_over_overlay.gd.uid
+++ b/godot/scenes/breakout/view/game_over_overlay.gd.uid
@@ -1,0 +1,1 @@
+uid://c1njgm0dmcya2

--- a/godot/scenes/breakout/view/hud.gd
+++ b/godot/scenes/breakout/view/hud.gd
@@ -1,0 +1,30 @@
+extends VBoxContainer
+## Breakout HUD: score, lives, level. Updated by parent on every visible
+## state change.
+
+const Palette := preload("res://scripts/breakout/brick_palette.gd")
+
+var _score_label: Label
+var _lives_label: Label
+var _level_label: Label
+
+func _ready() -> void:
+	add_theme_constant_override("separation", 8)
+	_score_label = _make_label("Score: 0", 28)
+	_lives_label = _make_label("Lives: 3", 20)
+	_level_label = _make_label("Level: 1", 18)
+	add_child(_score_label)
+	add_child(_lives_label)
+	add_child(_level_label)
+
+func _make_label(text: String, font_size: int) -> Label:
+	var l := Label.new()
+	l.text = text
+	l.add_theme_font_size_override("font_size", font_size)
+	l.add_theme_color_override("font_color", Palette.HUD_TEXT)
+	return l
+
+func update_from_snapshot(snap: Dictionary, level_index: int = 1) -> void:
+	_score_label.text = "Score: %d" % int(snap.get("score", 0))
+	_lives_label.text = "Lives: %d" % int(snap.get("lives", 0))
+	_level_label.text = "Level: %d" % level_index

--- a/godot/scenes/breakout/view/hud.gd.uid
+++ b/godot/scenes/breakout/view/hud.gd.uid
@@ -1,0 +1,1 @@
+uid://q0p88dxs3j5c

--- a/godot/scenes/breakout/view/life_lost_overlay.gd
+++ b/godot/scenes/breakout/view/life_lost_overlay.gd
@@ -1,0 +1,30 @@
+extends CanvasLayer
+## Brief "Get ready" overlay shown for ~800 ms after a life loss while the
+## ball returns to sticky. The scene drives visibility — this overlay only
+## paints. Layer 9 = below pause/game-over so they take precedence if the
+## player paused mid-life-loss.
+
+var _label: Label
+
+func _ready() -> void:
+	layer = 9
+	var bg := ColorRect.new()
+	bg.color = Color(0, 0, 0, 0.4)
+	bg.anchor_right = 1.0
+	bg.anchor_bottom = 1.0
+	add_child(bg)
+	_label = Label.new()
+	_label.text = "GET READY"
+	_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	_label.anchor_right = 1.0
+	_label.anchor_bottom = 1.0
+	_label.add_theme_font_size_override("font_size", 36)
+	add_child(_label)
+	visible = false
+
+func set_lives(lives_remaining: int) -> void:
+	if lives_remaining > 0:
+		_label.text = "GET READY — %d LIVES" % lives_remaining
+	else:
+		_label.text = "GET READY"

--- a/godot/scenes/breakout/view/life_lost_overlay.gd.uid
+++ b/godot/scenes/breakout/view/life_lost_overlay.gd.uid
@@ -1,0 +1,1 @@
+uid://coe2uwlfy3h52

--- a/godot/scenes/breakout/view/pause_overlay.gd
+++ b/godot/scenes/breakout/view/pause_overlay.gd
@@ -1,0 +1,46 @@
+extends CanvasLayer
+## Pause overlay for breakout. Layer 10. Mirrors the snake/2048 pattern.
+
+signal menu_requested()
+
+var _menu_btn: Button
+
+func _ready() -> void:
+	layer = 10
+	var bg := ColorRect.new()
+	bg.color = Color(0, 0, 0, 0.6)
+	bg.anchor_right = 1.0
+	bg.anchor_bottom = 1.0
+	add_child(bg)
+	var vbox := VBoxContainer.new()
+	vbox.alignment = BoxContainer.ALIGNMENT_CENTER
+	vbox.anchor_right = 1.0
+	vbox.anchor_bottom = 1.0
+	vbox.add_theme_constant_override("separation", 16)
+	add_child(vbox)
+	var label := Label.new()
+	label.text = "PAUSED"
+	label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	label.add_theme_font_size_override("font_size", 36)
+	vbox.add_child(label)
+	var hint := Label.new()
+	hint.text = "Press Pause to resume"
+	hint.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	hint.add_theme_font_size_override("font_size", 18)
+	vbox.add_child(hint)
+	_menu_btn = Button.new()
+	_menu_btn.text = "Back to menu"
+	_menu_btn.pressed.connect(func() -> void: menu_requested.emit())
+	vbox.add_child(_menu_btn)
+	visibility_changed.connect(_on_visibility_changed)
+	InputManager.action_pressed.connect(_on_action_pressed)
+
+func _on_visibility_changed() -> void:
+	if visible and is_instance_valid(_menu_btn):
+		_menu_btn.grab_focus()
+
+func _on_action_pressed(action: StringName) -> void:
+	if not visible:
+		return
+	if action == &"ui_cancel":
+		menu_requested.emit()

--- a/godot/scenes/breakout/view/pause_overlay.gd.uid
+++ b/godot/scenes/breakout/view/pause_overlay.gd.uid
@@ -1,0 +1,1 @@
+uid://cx1f35s7xh21o

--- a/godot/scenes/breakout/view/win_overlay.gd
+++ b/godot/scenes/breakout/view/win_overlay.gd
@@ -1,0 +1,59 @@
+extends CanvasLayer
+## Win overlay — fires when all destructible bricks are cleared.
+## ui_accept = retry (fresh game); ui_cancel = quit to menu.
+
+signal restart_requested()
+signal menu_requested()
+
+var _score_label: Label
+var _retry_btn: Button
+
+func _ready() -> void:
+	layer = 11   # Above game-over so a simultaneous transition is visible.
+	var bg := ColorRect.new()
+	bg.color = Color(0, 0, 0, 0.6)
+	bg.anchor_right = 1.0
+	bg.anchor_bottom = 1.0
+	add_child(bg)
+	var vbox := VBoxContainer.new()
+	vbox.alignment = BoxContainer.ALIGNMENT_CENTER
+	vbox.anchor_right = 1.0
+	vbox.anchor_bottom = 1.0
+	vbox.add_theme_constant_override("separation", 16)
+	add_child(vbox)
+	var title := Label.new()
+	title.text = "YOU WIN!"
+	title.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	title.add_theme_font_size_override("font_size", 48)
+	vbox.add_child(title)
+	_score_label = Label.new()
+	_score_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	_score_label.add_theme_font_size_override("font_size", 24)
+	vbox.add_child(_score_label)
+	_retry_btn = Button.new()
+	_retry_btn.text = "Retry"
+	_retry_btn.pressed.connect(func() -> void: restart_requested.emit())
+	vbox.add_child(_retry_btn)
+	var quit_btn := Button.new()
+	quit_btn.text = "Quit to menu"
+	quit_btn.pressed.connect(func() -> void: menu_requested.emit())
+	vbox.add_child(quit_btn)
+	visibility_changed.connect(_on_visibility_changed)
+	InputManager.action_pressed.connect(_on_action_pressed)
+	visible = false
+
+func show_with(score: int) -> void:
+	_score_label.text = "Score: %d" % score
+	visible = true
+
+func _on_visibility_changed() -> void:
+	if visible and is_instance_valid(_retry_btn):
+		_retry_btn.grab_focus()
+
+func _on_action_pressed(action: StringName) -> void:
+	if not visible:
+		return
+	if action == &"ui_accept":
+		restart_requested.emit()
+	elif action == &"ui_cancel":
+		menu_requested.emit()

--- a/godot/scenes/breakout/view/win_overlay.gd.uid
+++ b/godot/scenes/breakout/view/win_overlay.gd.uid
@@ -1,0 +1,1 @@
+uid://c6qxyn7pxgabo

--- a/godot/scenes/breakout/view/world.gd
+++ b/godot/scenes/breakout/view/world.gd
@@ -1,0 +1,75 @@
+extends Node2D
+## Breakout world renderer. Owns nothing; pulls from the latest snapshot
+## given by the parent. Single _draw method paints in three logical
+## passes (bricks → paddle → ball) ordered back-to-front; collapses to one
+## pass per frame because in this game the cost is dominated by the brick
+## count (~50–100) which is well within budget.
+##
+## The world is drawn in **world units** (config.world_w × config.world_h).
+## The parent applies a uniform scale + translation to letterbox it into
+## the available viewport.
+
+const Palette := preload("res://scripts/breakout/brick_palette.gd")
+
+var _world_w: float = 320.0
+var _world_h: float = 240.0
+var _ball_radius: float = 3.0
+var _snapshot: Dictionary = {}
+# Parallel array; mirrors level.cells so we can resolve color_id by idx for
+# bricks present in the latest snapshot (snapshot only carries idx + hp).
+var _brick_meta_by_idx: Dictionary = {}
+
+func configure(world_w: float, world_h: float, ball_radius: float, brick_meta_by_idx: Dictionary) -> void:
+	_world_w = world_w
+	_world_h = world_h
+	_ball_radius = ball_radius
+	_brick_meta_by_idx = brick_meta_by_idx
+	queue_redraw()
+
+func update_from_snapshot(snap: Dictionary) -> void:
+	_snapshot = snap
+	queue_redraw()
+
+func world_size() -> Vector2:
+	return Vector2(_world_w, _world_h)
+
+func _draw() -> void:
+	# Background (the playfield itself; letterboxing is parent's job).
+	draw_rect(Rect2(Vector2.ZERO, Vector2(_world_w, _world_h)), Palette.BG, true)
+	if _snapshot.is_empty():
+		return
+	# Bricks.
+	var bricks: Array = _snapshot.get("bricks", [])
+	for entry in bricks:
+		var idx: int = int(entry.get("idx", -1))
+		if idx < 0:
+			continue
+		var meta: Dictionary = _brick_meta_by_idx.get(idx, {})
+		if meta.is_empty():
+			continue
+		var cx: float = float(meta.get("cx", 0.0))
+		var cy: float = float(meta.get("cy", 0.0))
+		var hx: float = float(meta.get("hx", 0.0))
+		var hy: float = float(meta.get("hy", 0.0))
+		var color_id: int = int(meta.get("color_id", 0))
+		var destructible: bool = bool(meta.get("destructible", true))
+		var color: Color = Palette.for_color_id(color_id, destructible)
+		var rect := Rect2(Vector2(cx - hx, cy - hy), Vector2(hx * 2.0, hy * 2.0))
+		draw_rect(rect, color, true)
+		# 1px inner border for subtle separation.
+		draw_rect(rect, Color(0, 0, 0, 0.35), false, 1.0)
+	# Paddle.
+	var paddle: Dictionary = _snapshot.get("paddle", {})
+	if not paddle.is_empty():
+		var px: float = float(paddle.get("x", 0.0))
+		var pw: float = float(paddle.get("w", 0.0))
+		var ph: float = float(paddle.get("h", 0.0))
+		var py: float = float(paddle.get("y", 0.0))
+		draw_rect(Rect2(Vector2(px - pw * 0.5, py), Vector2(pw, ph)), Palette.PADDLE, true)
+	# Ball — drawn as a filled circle even though core treats it as AABB.
+	var ball: Dictionary = _snapshot.get("ball", {})
+	if not ball.is_empty():
+		var bx: float = float(ball.get("x", 0.0))
+		var by: float = float(ball.get("y", 0.0))
+		var br: float = float(ball.get("r", _ball_radius))
+		draw_circle(Vector2(bx, by), br, Palette.BALL)

--- a/godot/scenes/breakout/view/world.gd.uid
+++ b/godot/scenes/breakout/view/world.gd.uid
@@ -1,0 +1,1 @@
+uid://cd5exv1yg2oon

--- a/godot/scripts/breakout/brick_palette.gd
+++ b/godot/scripts/breakout/brick_palette.gd
@@ -1,0 +1,32 @@
+extends RefCounted
+## Brick color palette for breakout. color_id is set per-cell in the level
+## resource; the scene resolves it to a Color via `for_color_id`.
+##
+## Indestructible bricks (passed via `destructible=false`) render in a flat
+## gray that's clearly distinct from any normal palette entry, regardless of
+## their color_id. This keeps level files terse: a level can stamp them all
+## with color_id=0 and trust the renderer to surface their special role.
+
+const _COLORS: Array[Color] = [
+	Color(0.86, 0.30, 0.30),   # 0 — red
+	Color(0.95, 0.70, 0.25),   # 1 — orange
+	Color(0.96, 0.90, 0.36),   # 2 — yellow
+	Color(0.45, 0.78, 0.40),   # 3 — green
+	Color(0.40, 0.65, 0.92),   # 4 — blue
+	Color(0.66, 0.46, 0.86),   # 5 — purple
+]
+
+const _INDESTRUCTIBLE: Color = Color(0.45, 0.45, 0.48)
+
+const BG: Color = Color(0.07, 0.07, 0.10)
+const PADDLE: Color = Color(0.92, 0.92, 0.95)
+const BALL: Color = Color(0.98, 0.98, 0.98)
+const HUD_TEXT: Color = Color(0.92, 0.92, 0.95)
+const LETTERBOX: Color = Color.BLACK
+
+static func for_color_id(color_id: int, destructible: bool = true) -> Color:
+	if not destructible:
+		return _INDESTRUCTIBLE
+	if color_id < 0 or color_id >= _COLORS.size():
+		return _COLORS[0]
+	return _COLORS[color_id]

--- a/godot/scripts/breakout/brick_palette.gd.uid
+++ b/godot/scripts/breakout/brick_palette.gd.uid
@@ -1,0 +1,1 @@
+uid://ddymngxowve4r

--- a/godot/scripts/core/game/game_registry.gd
+++ b/godot/scripts/core/game/game_registry.gd
@@ -12,6 +12,7 @@ const _GAMES: Array = [
 	[&"tetris", "Tetris", "res://scenes/tetris/tetris.tscn", ""],
 	[&"snake", "Snake", "res://scenes/snake/snake.tscn", ""],
 	[&"g2048", "2048", "res://scenes/g2048/g2048.tscn", ""],
+	[&"breakout", "Breakout", "res://scenes/breakout/breakout.tscn", ""],
 ]
 
 static func all() -> Array:

--- a/godot/tests/integration/test_breakout_scene.gd
+++ b/godot/tests/integration/test_breakout_scene.gd
@@ -1,0 +1,143 @@
+extends GutTest
+## Scene-level integration test for breakout. Drives the scene via Input
+## actions so InputManager's real path runs (matches snake/g2048 patterns).
+##
+## Determinism: scene.start(SEED) replaces BreakoutGameState with a fresh,
+## seeded one in before_each.
+
+const ActionMapDefaults := preload("res://scripts/core/input/action_map_defaults.gd")
+const BreakoutGameState := preload("res://scripts/breakout/core/breakout_state.gd")
+const BreakoutLevel := preload("res://scripts/breakout/core/breakout_level.gd")
+
+const SEED: int = 12345
+
+var scene: Control
+
+
+func before_each() -> void:
+	for action in ActionMapDefaults.ACTIONS:
+		Input.action_release(action)
+	await get_tree().process_frame
+	await get_tree().process_frame
+	var packed: PackedScene = load("res://scenes/breakout/breakout.tscn")
+	scene = packed.instantiate()
+	add_child(scene)
+	await get_tree().process_frame
+	scene.start(SEED)
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+
+func after_each() -> void:
+	for action in ActionMapDefaults.ACTIONS:
+		Input.action_release(action)
+	if is_instance_valid(scene):
+		scene.queue_free()
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+
+func _press_release(action: StringName) -> void:
+	Input.action_press(action)
+	await get_tree().process_frame
+	await get_tree().process_frame
+	Input.action_release(action)
+	await get_tree().process_frame
+
+
+# --- Tests ---
+
+
+func test_starts_in_sticky_with_full_lives() -> void:
+	# Acceptance #5: sticky on start; HUD shows lives_start.
+	var snap: Dictionary = scene.state.snapshot()
+	assert_eq(int(snap.get("mode", -1)), BreakoutGameState.Mode.STICKY,
+		"breakout starts in sticky mode")
+	assert_eq(int(snap.get("lives", 0)), scene.config.lives_start,
+		"starts with lives_start lives")
+	assert_eq(int(snap.get("score", -1)), 0, "starts with zero score")
+
+
+func test_hard_drop_action_launches_ball() -> void:
+	# Acceptance #5: launch leaves sticky.
+	assert_eq(scene.state.mode, BreakoutGameState.Mode.STICKY)
+	await _press_release(&"hard_drop")
+	# Allow one process tick for state.tick to advance.
+	await get_tree().process_frame
+	assert_eq(scene.state.mode, BreakoutGameState.Mode.LIVE,
+		"hard_drop launches ball into LIVE mode")
+	assert_ne(scene.state.ball_vy, 0.0, "ball has non-zero vy after launch")
+
+
+func test_move_right_drives_paddle_intent() -> void:
+	# Acceptance #3: paddle responds within one frame to keypress.
+	var initial_x: float = scene.state.paddle_x
+	Input.action_press(&"move_right")
+	# Two process frames for InputManager → scene → state.tick to apply.
+	await get_tree().process_frame
+	await get_tree().process_frame
+	await get_tree().process_frame
+	Input.action_release(&"move_right")
+	assert_gt(scene.state.paddle_x, initial_x,
+		"paddle x increased after holding move_right")
+
+
+func test_pause_blocks_paddle_motion() -> void:
+	# Acceptance: pause stops the sim.
+	await _press_release(&"hard_drop")
+	await get_tree().process_frame
+	await _press_release(&"pause")
+	await get_tree().process_frame
+	assert_true(scene.pause_overlay.visible, "pause overlay visible")
+	var x_at_pause: float = scene.state.paddle_x
+	var ball_x_at_pause: float = scene.state.ball_x
+	# Hold move_right for several frames; nothing should happen.
+	Input.action_press(&"move_right")
+	for _i in 5:
+		await get_tree().process_frame
+	Input.action_release(&"move_right")
+	assert_almost_eq(scene.state.paddle_x, x_at_pause, 0.01,
+		"paddle did not move while paused")
+	assert_almost_eq(scene.state.ball_x, ball_x_at_pause, 0.01,
+		"ball did not move while paused")
+	# Resume.
+	await _press_release(&"pause")
+	assert_false(scene.pause_overlay.visible, "pause overlay hidden after resume")
+
+
+func test_game_over_overlay_path() -> void:
+	# Force LOST mode and let the scene react.
+	scene.state.mode = BreakoutGameState.Mode.LOST
+	scene.state.lives = 0
+	for _i in 5:
+		await get_tree().process_frame
+	assert_true(scene.game_over_overlay.visible,
+		"game-over overlay visible once state is LOST")
+
+
+func test_win_overlay_path() -> void:
+	# Force WON mode and let the scene react.
+	scene.state.mode = BreakoutGameState.Mode.WON
+	for _i in 5:
+		await get_tree().process_frame
+	assert_true(scene.win_overlay.visible,
+		"win overlay visible once state is WON")
+
+
+func test_restart_after_game_over_resets_state() -> void:
+	# Force a game over.
+	scene.state.mode = BreakoutGameState.Mode.LOST
+	scene.state.lives = 0
+	for _i in 5:
+		await get_tree().process_frame
+	assert_true(scene.game_over_overlay.visible)
+	# Restart via scene method (UI-equivalent).
+	scene._on_restart_pressed()
+	await get_tree().process_frame
+	await get_tree().process_frame
+	assert_eq(scene.state.mode, BreakoutGameState.Mode.STICKY,
+		"restart returns to STICKY mode")
+	assert_eq(scene.state.lives, scene.config.lives_start,
+		"restart restores lives_start lives")
+	assert_false(scene.game_over_overlay.visible,
+		"game-over overlay hidden after restart")

--- a/godot/tests/integration/test_breakout_scene.gd.uid
+++ b/godot/tests/integration/test_breakout_scene.gd.uid
@@ -1,0 +1,1 @@
+uid://bd2ejfk3to8w1

--- a/godot/tests/integration/test_breakout_session.gd
+++ b/godot/tests/integration/test_breakout_session.gd
@@ -1,0 +1,89 @@
+extends GutTest
+## Integration: scripted seed + intent + ticks → expected snapshot stream.
+## Bypasses the scene + input layer entirely; drives BreakoutGameState
+## directly. Catches non-determinism that the scene test can't surface
+## because of wall-clock timing.
+
+const BreakoutConfig := preload("res://scripts/breakout/core/breakout_config.gd")
+const BreakoutLevel := preload("res://scripts/breakout/core/breakout_level.gd")
+const BreakoutGameState := preload("res://scripts/breakout/core/breakout_state.gd")
+
+const SEED: int = 4242
+
+func _make_level() -> BreakoutLevel:
+	# Tiny 2×2 destructible grid for fast termination.
+	var lvl := BreakoutLevel.new()
+	lvl.rows = 2
+	lvl.cols = 2
+	lvl.brick_w = 40.0
+	lvl.brick_h = 16.0
+	lvl.origin_x = 80.0
+	lvl.origin_y = 30.0
+	lvl.cells = [
+		{"hp": 1, "value": 100, "destructible": true, "color_id": 0},
+		{"hp": 1, "value": 100, "destructible": true, "color_id": 1},
+		{"hp": 1, "value": 100, "destructible": true, "color_id": 2},
+		{"hp": 1, "value": 100, "destructible": true, "color_id": 3},
+	]
+	return lvl
+
+func _make_state() -> BreakoutGameState:
+	var cfg := BreakoutConfig.new()
+	return BreakoutGameState.create(SEED, cfg, _make_level())
+
+
+func test_same_seed_same_intents_same_snapshot_stream() -> void:
+	# Two parallel runs with identical inputs should produce byte-identical
+	# snapshot streams.
+	var a := _make_state()
+	var b := _make_state()
+	a.launch()
+	b.launch()
+	var snaps_a: Array[Dictionary] = []
+	var snaps_b: Array[Dictionary] = []
+	for i in 200:
+		# Apply a paddle-intent oscillation that exercises clamp + reflection.
+		var intent: float = 120.0 if (i % 60) < 30 else -120.0
+		a.set_paddle_intent(intent)
+		b.set_paddle_intent(intent)
+		var t: int = i * 16
+		a.tick(t)
+		b.tick(t)
+		snaps_a.append(a.snapshot())
+		snaps_b.append(b.snapshot())
+	assert_eq(snaps_a, snaps_b, "snapshot streams must match for identical seed+intents")
+
+
+func test_session_with_paddle_off_screen_ends_in_game_over() -> void:
+	# One-life run with paddle parked in a corner: ball falls past it and
+	# lives drain to zero. Bounds iteration count so a regression doesn't
+	# hang the suite. Confirms: launch → ball motion → life loss → LOST.
+	var cfg := BreakoutConfig.new()
+	cfg.lives_start = 1
+	var s := BreakoutGameState.create(SEED, cfg, _make_level())
+	s.paddle_x = 0.0
+	s.launch()
+	var step: int = 0
+	var t: int = 0
+	while not s.is_game_over() and step < 5000:
+		t += 16
+		s.tick(t)
+		step += 1
+	assert_true(s.is_game_over(), "session ends in LOST mode when paddle is parked")
+	assert_eq(s.lives, 0, "lives drain to zero")
+
+
+func test_snapshot_carries_version() -> void:
+	var s := _make_state()
+	var snap: Dictionary = s.snapshot()
+	assert_eq(int(snap.get("version", -1)), BreakoutGameState.SCHEMA_VERSION,
+		"snapshot must carry schema version")
+
+
+func test_set_paddle_intent_clamped_to_max() -> void:
+	# Acceptance: clamp at apply, so a huge intent doesn't bypass max_speed.
+	var s := _make_state()
+	s.set_paddle_intent(99999.0)
+	assert_almost_eq(s.paddle_intent_vx, s.config.paddle_max_speed_px_s, 0.001)
+	s.set_paddle_intent(-99999.0)
+	assert_almost_eq(s.paddle_intent_vx, -s.config.paddle_max_speed_px_s, 0.001)

--- a/godot/tests/integration/test_breakout_session.gd.uid
+++ b/godot/tests/integration/test_breakout_session.gd.uid
@@ -1,0 +1,1 @@
+uid://di6dswa6hsms4


### PR DESCRIPTION
Closes #22

Per-game scene wrapping `BreakoutGameState` from #17. Implements the GameHost
contract (start/pause/resume/teardown + exit_requested / score_reported).

- Renders paddle (rect), ball (circle), bricks (rects with palette by color_id)
  in world-units; parent applies a fit-letterbox transform to BoardHost.
- Input: digital + analog paddle intent via `Input.get_action_strength`,
  `hard_drop` action launches the ball, touch drag moves the paddle target,
  tap on lower 25% of the playfield also launches.
- HUD: score, lives, level. Overlays: pause, "Get ready" (~800 ms after life
  loss), game-over, win.
- One built-in level (`scenes/breakout/levels/level_01.tres`, 6×10 destructible
  bricks colored by row).
- Registered in `GameRegistry` so the menu surfaces it automatically.

## How tested
- `tests/integration/test_breakout_session.gd` — determinism (same seed +
  same intents → byte-identical snapshot streams), bounded termination
  (parked paddle + 1 life → LOST in <5000 ticks), schema version, intent
  clamp.
- `tests/integration/test_breakout_scene.gd` — sticky/lives at start,
  hard_drop launches, move_right drives paddle, pause blocks paddle/ball,
  game-over and win overlay paths, restart resets state.
- All 276 GUT tests pass headless on Godot 4.6.2.

## Estimated effective diff
793 lines (total 1027, excluded 234). The 331-line `breakout.gd` carries the
per-frame intent/letterbox/touch/overlay wiring; the rest is small overlay
files mirroring the snake/2048 patterns.

⚠️ Exceeds 400 effective lines. Issue must carry the `large-pr-ok` label for
auto-merge; otherwise human review will be required.