### PR TITLE
feat(invaders): pure logic core (formation + AABB + bunkers + UFO)

### DIFF
--- a/godot/scripts/invaders/core/aabb.gd
+++ b/godot/scripts/invaders/core/aabb.gd
@@ -1,0 +1,17 @@
+extends RefCounted
+## Pure AABB helpers for invaders. No Node, no Engine APIs. Local copy —
+## intentionally not bridged to breakout/core to keep cross-game coupling
+## at zero (per Dev plan: "aabb.gd is local").
+##
+## An AABB is `(cx, cy, hx, hy)` — center + half-extents.
+
+const Self := preload("res://scripts/invaders/core/aabb.gd")
+
+
+## True iff the two AABBs share strictly positive area. Edge-touching
+## (depth == 0) is NOT considered overlap.
+static func overlaps(acx: float, acy: float, ahx: float, ahy: float,
+		bcx: float, bcy: float, bhx: float, bhy: float) -> bool:
+	var dx: float = absf(acx - bcx)
+	var dy: float = absf(acy - bcy)
+	return ((ahx + bhx) - dx) > 0.0 and ((ahy + bhy) - dy) > 0.0

--- a/godot/scripts/invaders/core/bunker_erosion.gd
+++ b/godot/scripts/invaders/core/bunker_erosion.gd
@@ -1,0 +1,65 @@
+extends RefCounted
+## bunker_erosion.gd — canonical erosion stamps for player-up and
+## enemy-down bullet impacts. Stamps are inline ASCII bit-pattern
+## constants; tests use them as the oracle (see Dev plan §Algorithms).
+##
+## A stamp is a flat PackedByteArray of length stamp_w * stamp_h. 1 means
+## "clear that cell"; 0 means "leave it". The caller's anchor coordinates
+## decide where the stamp lands on the bunker grid.
+##
+## Anchor convention:
+##   - PLAYER_UP_STAMP anchor is the bottom-center of the stamp; aligns
+##     with the cell the bullet was last in (the bottom of the bunker).
+##   - ENEMY_DOWN_STAMP anchor is the top-center of the stamp; aligns with
+##     the cell the bullet entered (the top of the bunker).
+
+const Self := preload("res://scripts/invaders/core/bunker_erosion.gd")
+
+
+# 5 wide × 3 tall — player bullet eats UPWARD into the bunker bottom.
+# Anchor (sx=2, sy=2) is the bottom-center cell of the stamp.
+const PLAYER_UP_W: int = 5
+const PLAYER_UP_H: int = 3
+const PLAYER_UP_ANCHOR_SX: int = 2
+const PLAYER_UP_ANCHOR_SY: int = 2
+
+const _PLAYER_UP_ASCII: Array = [
+	".XXX.",
+	"XXXXX",
+	"XXXXX",
+]
+
+
+# 5 wide × 4 tall — enemy bullet eats DOWNWARD into the bunker top.
+# Anchor (sx=2, sy=0) is the top-center cell of the stamp. The hollowed
+# bottom rows give the classic "bite mark" look without overshooting.
+const ENEMY_DOWN_W: int = 5
+const ENEMY_DOWN_H: int = 4
+const ENEMY_DOWN_ANCHOR_SX: int = 2
+const ENEMY_DOWN_ANCHOR_SY: int = 0
+
+const _ENEMY_DOWN_ASCII: Array = [
+	"XXXXX",
+	"XXXXX",
+	"X...X",
+	".X.X.",
+]
+
+
+static func player_up_stamp() -> PackedByteArray:
+	return _ascii_to_bits(_PLAYER_UP_ASCII, PLAYER_UP_W, PLAYER_UP_H)
+
+
+static func enemy_down_stamp() -> PackedByteArray:
+	return _ascii_to_bits(_ENEMY_DOWN_ASCII, ENEMY_DOWN_W, ENEMY_DOWN_H)
+
+
+static func _ascii_to_bits(ascii: Array, sw: int, sh: int) -> PackedByteArray:
+	var out: PackedByteArray = PackedByteArray()
+	out.resize(sw * sh)
+	for sy in range(sh):
+		var s: String = ascii[sy]
+		assert(s.length() == sw, "stamp row %d wrong width" % sy)
+		for sx in range(sw):
+			out[sy * sw + sx] = 1 if s[sx] == "X" else 0
+	return out

--- a/godot/scripts/invaders/core/bunker_grid.gd
+++ b/godot/scripts/invaders/core/bunker_grid.gd
@@ -1,0 +1,115 @@
+extends RefCounted
+## bunker_grid.gd — pure 2D pixel grid (1 = filled, 0 = empty), row-major.
+## Backed by a PackedByteArray for cheap snapshot/restore. No Node, no
+## Engine APIs.
+##
+## Coordinate semantics:
+##   - cell coords (cx, cy) are integer column/row indices, 0-based.
+##   - The bunker as a whole sits at world position `origin_x, origin_y`
+##     (top-left corner). World→cell is the caller's job.
+##
+## Mutation contract: `clear_cell` and `apply_stamp` set bits to 0 only.
+## Bunkers never grow back — bullets erode them monotonically.
+
+const Self := preload("res://scripts/invaders/core/bunker_grid.gd")
+
+var w: int = 0
+var h: int = 0
+var cells: PackedByteArray = PackedByteArray()
+
+
+static func create(width: int, height: int, pattern: PackedByteArray) -> Self:
+	var g: Self = Self.new()
+	g.w = width
+	g.h = height
+	assert(pattern.size() == width * height, "bunker pattern size mismatch")
+	# Copy so subsequent mutations don't aliase the level resource.
+	var buf: PackedByteArray = PackedByteArray()
+	buf.resize(pattern.size())
+	for i in range(pattern.size()):
+		buf[i] = pattern[i]
+	g.cells = buf
+	return g
+
+
+func get_cell(cx: int, cy: int) -> int:
+	if cx < 0 or cx >= w or cy < 0 or cy >= h:
+		return 0
+	return cells[cy * w + cx]
+
+
+func clear_cell(cx: int, cy: int) -> void:
+	if cx < 0 or cx >= w or cy < 0 or cy >= h:
+		return
+	cells[cy * w + cx] = 0
+
+
+## Apply an erosion stamp anchored at (anchor_cx, anchor_cy). The stamp is
+## a flat `(stamp_w * stamp_h)` PackedByteArray (1 = clear that cell).
+## `anchor_in_stamp` is the (sx, sy) coord WITHIN the stamp that maps to
+## the bunker's `(anchor_cx, anchor_cy)`. Out-of-bounds cells are silently
+## clipped. Returns the number of bits actually cleared (could be 0 if the
+## stamp lands entirely on already-empty cells or off-grid).
+func apply_stamp(stamp: PackedByteArray, stamp_w: int, stamp_h: int,
+		anchor_cx: int, anchor_cy: int, anchor_sx: int, anchor_sy: int) -> int:
+	var cleared: int = 0
+	for sy in range(stamp_h):
+		for sx in range(stamp_w):
+			if stamp[sy * stamp_w + sx] == 0:
+				continue
+			var bx: int = anchor_cx + (sx - anchor_sx)
+			var by: int = anchor_cy + (sy - anchor_sy)
+			if bx < 0 or bx >= w or by < 0 or by >= h:
+				continue
+			if cells[by * w + bx] != 0:
+				cells[by * w + bx] = 0
+				cleared += 1
+	return cleared
+
+
+## Returns true iff any cell of the bunker overlaps the AABB
+## `(cx, cy, hx, hy)` in world coords (origin_x, origin_y is the bunker's
+## top-left). This is the broad-phase used by bullet collision: scan the
+## intersected cell range, return on first filled cell. The intersect cell
+## (cx, cy) is returned via the out_dict if hit.
+func aabb_hit(origin_x: float, origin_y: float, cell_w: float, cell_h: float,
+		bx: float, by: float, bhx: float, bhy: float, out_dict: Dictionary) -> bool:
+	# Convert AABB extent to cell range (inclusive).
+	var min_cx: int = int(floor((bx - bhx - origin_x) / cell_w))
+	var max_cx: int = int(floor((bx + bhx - origin_x - 0.0001) / cell_w))
+	var min_cy: int = int(floor((by - bhy - origin_y) / cell_h))
+	var max_cy: int = int(floor((by + bhy - origin_y - 0.0001) / cell_h))
+	min_cx = clampi(min_cx, 0, w - 1)
+	max_cx = clampi(max_cx, 0, w - 1)
+	min_cy = clampi(min_cy, 0, h - 1)
+	max_cy = clampi(max_cy, 0, h - 1)
+	if min_cx > max_cx or min_cy > max_cy:
+		return false
+	for cy in range(min_cy, max_cy + 1):
+		for cx in range(min_cx, max_cx + 1):
+			if cells[cy * w + cx] != 0:
+				out_dict["cx"] = cx
+				out_dict["cy"] = cy
+				return true
+	return false
+
+
+func snapshot_cells() -> PackedByteArray:
+	# Return a copy so callers can't mutate our internal state.
+	var out: PackedByteArray = PackedByteArray()
+	out.resize(cells.size())
+	for i in range(cells.size()):
+		out[i] = cells[i]
+	return out
+
+
+static func from_snapshot(width: int, height: int, snap_cells: PackedByteArray) -> Self:
+	var g: Self = Self.new()
+	g.w = width
+	g.h = height
+	var buf: PackedByteArray = PackedByteArray()
+	buf.resize(snap_cells.size())
+	for i in range(snap_cells.size()):
+		buf[i] = snap_cells[i]
+	g.cells = buf
+	return g

--- a/godot/scripts/invaders/core/bunker_grid.gd
+++ b/godot/scripts/invaders/core/bunker_grid.gd
@@ -79,6 +79,10 @@ func aabb_hit(origin_x: float, origin_y: float, cell_w: float, cell_h: float,
 	var max_cx: int = int(floor((bx + bhx - origin_x - 0.0001) / cell_w))
 	var min_cy: int = int(floor((by - bhy - origin_y) / cell_h))
 	var max_cy: int = int(floor((by + bhy - origin_y - 0.0001) / cell_h))
+	# Reject if the AABB lies entirely outside the grid before clamping —
+	# clamping would otherwise mash an out-of-range range onto an edge cell.
+	if max_cx < 0 or min_cx >= w or max_cy < 0 or min_cy >= h:
+		return false
 	min_cx = clampi(min_cx, 0, w - 1)
 	max_cx = clampi(max_cx, 0, w - 1)
 	min_cy = clampi(min_cy, 0, h - 1)

--- a/godot/scripts/invaders/core/formation.gd
+++ b/godot/scripts/invaders/core/formation.gd
@@ -1,0 +1,114 @@
+extends RefCounted
+## formation.gd — pure helpers for the invader formation. No state held;
+## the caller (InvadersGameState) owns the live mask + origin and passes
+## them in. No Node, no Engine APIs.
+##
+## Coordinate model:
+##   - The formation has an origin (ox, oy) in world coords (top-left of
+##     the grid's cell 0,0).
+##   - Cell (col, row) center is at:
+##         cx = ox + col * cell_w + cell_w * 0.5
+##         cy = oy + row * cell_h + cell_h * 0.5
+##   - Live mask is a flat PackedByteArray, length rows*cols, 1 = alive.
+##
+## The "reasoning" comments below explain why each helper exists, not what
+## the code literally does — see the Dev plan in #27 for the full spec.
+
+
+## Returns the (min_x_left, max_x_right) world bounds of all live cells in
+## the formation (inclusive: min is left edge of leftmost alive, max is
+## right edge of rightmost alive). Used to detect edge-bounce.
+##
+## Returns (-INF, -INF) if the formation has no live cells.
+static func bounds_x(live_mask: PackedByteArray, rows: int, cols: int,
+		ox: float, oy: float, cell_w: float, cell_h: float,
+		enemy_hx: float) -> Vector2:
+	var min_col: int = -1
+	var max_col: int = -1
+	for col in range(cols):
+		var any_alive: bool = false
+		for row in range(rows):
+			if live_mask[row * cols + col] == 1:
+				any_alive = true
+				break
+		if any_alive:
+			if min_col == -1:
+				min_col = col
+			max_col = col
+	if min_col == -1:
+		return Vector2(-INF, -INF)
+	# Each cell's center x then ± enemy_hx for edges.
+	var lcx: float = ox + min_col * cell_w + cell_w * 0.5
+	var rcx: float = ox + max_col * cell_w + cell_w * 0.5
+	return Vector2(lcx - enemy_hx, rcx + enemy_hx)
+
+
+## Returns the (min_y_top, max_y_bottom) of the formation. Used by the
+## "any enemy crossed player line" loss check.
+static func bounds_y(live_mask: PackedByteArray, rows: int, cols: int,
+		ox: float, oy: float, cell_w: float, cell_h: float,
+		enemy_hy: float) -> Vector2:
+	var min_row: int = -1
+	var max_row: int = -1
+	for row in range(rows):
+		var any_alive: bool = false
+		for col in range(cols):
+			if live_mask[row * cols + col] == 1:
+				any_alive = true
+				break
+		if any_alive:
+			if min_row == -1:
+				min_row = row
+			max_row = row
+	if min_row == -1:
+		return Vector2(-INF, -INF)
+	var tcy: float = oy + min_row * cell_h + cell_h * 0.5
+	var bcy: float = oy + max_row * cell_h + cell_h * 0.5
+	return Vector2(tcy - enemy_hy, bcy + enemy_hy)
+
+
+## Number of live enemies in the mask.
+static func live_count(live_mask: PackedByteArray) -> int:
+	var n: int = 0
+	for i in range(live_mask.size()):
+		if live_mask[i] == 1:
+			n += 1
+	return n
+
+
+## Speed curve: linear lerp between min_step_ms (1 enemy left) and
+## step_ms_init (full population).
+##   step_ms = lerp(min_step_ms, step_ms_init, live / total)
+## Documented in Dev plan §Algorithms — deliberate departure from arcade's
+## piecewise-stepped table. A future config swap can restore arcade-faithful
+## behaviour.
+static func step_ms_for_population(live: int, total: int,
+		step_ms_init: int, min_step_ms: int) -> int:
+	if total <= 0:
+		return min_step_ms
+	var t: float = float(live) / float(total)
+	t = clampf(t, 0.0, 1.0)
+	var ms: float = lerpf(float(min_step_ms), float(step_ms_init), t)
+	return int(round(ms))
+
+
+## Find the column to fire from, given a uniform-random column index in
+## [0, cols). If the chosen column has no live enemy, walks rightward
+## until finding one. Returns -1 iff no live column exists.
+static func find_firing_column(live_mask: PackedByteArray, rows: int, cols: int,
+		seed_col: int) -> int:
+	var c: int = seed_col % cols
+	for _i in range(cols):
+		for row in range(rows):
+			if live_mask[row * cols + c] == 1:
+				return c
+		c = (c + 1) % cols
+	return -1
+
+
+## Bottom-most live row in `col`. Returns -1 if column is empty.
+static func bottom_row(live_mask: PackedByteArray, rows: int, cols: int, col: int) -> int:
+	for row in range(rows - 1, -1, -1):
+		if live_mask[row * cols + col] == 1:
+			return row
+	return -1

--- a/godot/scripts/invaders/core/invaders_config.gd
+++ b/godot/scripts/invaders/core/invaders_config.gd
@@ -1,0 +1,78 @@
+extends Resource
+## Invaders configuration. Pure value object — no Node, no signals.
+## Validated at create() time; tunneling-cap constraint is hard-asserted.
+##
+## All units: float pixels, int milliseconds. World origin top-left, +Y down.
+
+# --- World ---
+@export var world_w: float = 224.0
+@export var world_h: float = 256.0
+
+# --- Formation grid ---
+@export var rows: int = 5
+@export var cols: int = 11
+@export var cell_w: float = 16.0          # horizontal stride between cells
+@export var cell_h: float = 14.0          # vertical stride between rows
+@export var enemy_hx: float = 6.0         # half-extent x of an enemy AABB
+@export var enemy_hy: float = 5.0         # half-extent y of an enemy AABB
+
+# Formation origin (top-left of the grid) at wave 1.
+@export var formation_start_x: float = 16.0
+@export var formation_start_y: float = 40.0
+
+# Step cadence: every step_ms_init at full population, accelerating to
+# min_step_ms when only one enemy remains.
+@export var step_ms_init: int = 800
+@export var min_step_ms: int = 80
+@export var step_dx: float = 8.0          # horizontal shift per step
+@export var step_dy: float = 8.0          # vertical drop on edge bounce
+
+# --- Player ---
+@export var player_w: float = 16.0
+@export var player_h: float = 8.0
+@export var player_y: float = 232.0       # center y; top edge at player_y - h/2
+@export var player_max_speed_px_s: float = 90.0
+@export var lives_start: int = 3
+@export var invuln_ms: int = 1500
+
+# --- Bullets ---
+@export var player_bullet_w: float = 2.0
+@export var player_bullet_h: float = 6.0
+@export var player_bullet_speed: float = 220.0  # px/sec, upward
+@export var enemy_bullet_w: float = 2.0
+@export var enemy_bullet_h: float = 6.0
+@export var enemy_bullet_speed: float = 90.0    # px/sec, downward
+
+# Per-tick (fixed 16 ms sub-step) probability that an enemy bullet spawns.
+@export var enemy_fire_p_init: float = 0.012
+# Cap on simultaneous enemy bullets at wave 1.
+@export var enemy_bullets_max_init: int = 3
+# Cap goes up by +1 every N waves.
+@export var enemy_bullets_per_wave: int = 1
+@export var enemy_bullets_wave_step: int = 1
+
+# --- Bunkers ---
+@export var bunker_count: int = 4
+@export var bunker_cell_w: float = 2.0
+@export var bunker_cell_h: float = 2.0
+@export var bunker_y: float = 188.0       # center y of bunker rect
+
+# --- UFO ---
+@export var ufo_w: float = 16.0
+@export var ufo_h: float = 7.0
+@export var ufo_y: float = 32.0           # center y
+@export var ufo_speed: float = 60.0
+@export var ufo_interval_ms_init: int = 25000
+@export var ufo_jitter_ms: int = 5000     # ± half on each side
+
+# --- Wave progression ---
+# Each wave: formation_start_y -= wave_drop_y (clamped >= wave_min_start_y).
+@export var wave_drop_y: float = 8.0
+@export var wave_min_start_y: float = 24.0
+# step_ms_init shrinks by this factor each wave (multiplicative; clamped).
+@export var wave_speed_factor: float = 0.92
+
+# --- Time ---
+# Internal fixed sub-step (60 Hz physics).
+@export var sub_step_ms: int = 16
+@export var max_sub_steps_per_tick: int = 8

--- a/godot/scripts/invaders/core/invaders_level.gd
+++ b/godot/scripts/invaders/core/invaders_level.gd
@@ -1,0 +1,51 @@
+extends Resource
+## Invaders level — per-row enemy kind + value table, plus the canonical
+## bunker stamp. Pure data record, no Node.
+##
+## Rows are top-down: row 0 is the top row of the formation (worth more).
+## `row_kinds[r]` returns a kind id; `row_values[r]` returns score awarded
+## when that row's enemy is destroyed.
+##
+## The bunker stamp is one canonical pattern; `InvadersGameState.create()`
+## replicates it `config.bunker_count` times across the bunker row.
+
+# kind ids: 0 = bottom row (squid 10), 1 = mid rows (crab 20), 2 = top (octopus 30)
+@export var row_kinds: PackedByteArray = PackedByteArray([2, 1, 1, 0, 0])
+@export var row_values: PackedInt32Array = PackedInt32Array([30, 20, 20, 10, 10])
+
+# Canonical bunker grid (1 = filled, 0 = empty). Row-major.
+# Trapezoidal silhouette with arched notch at the bottom-center.
+# 22 wide × 16 tall = 352 cells.
+@export var bunker_w_cells: int = 22
+@export var bunker_h_cells: int = 16
+@export var bunker_pattern: PackedByteArray = _default_bunker_pattern()
+
+
+static func _default_bunker_pattern() -> PackedByteArray:
+	# Each row literal MUST be exactly 22 characters. Hand-drawn silhouette.
+	var rows_ascii: PackedStringArray = PackedStringArray([
+		"....11111111111111....",  # 0  trapezoidal top
+		"...1111111111111111...",  # 1
+		"..111111111111111111..",  # 2
+		".11111111111111111111.",  # 3
+		"1111111111111111111111",  # 4
+		"1111111111111111111111",  # 5
+		"1111111111111111111111",  # 6
+		"1111111111111111111111",  # 7
+		"1111111111111111111111",  # 8
+		"1111111111111111111111",  # 9
+		"1111111111111111111111",  # 10
+		"1111111........1111111",  # 11 notch begins
+		"111111..........111111",  # 12
+		"11111............11111",  # 13
+		"11111............11111",  # 14
+		"11111............11111",  # 15
+	])
+	var out: PackedByteArray = PackedByteArray()
+	out.resize(22 * 16)
+	for r in range(16):
+		var s: String = rows_ascii[r]
+		assert(s.length() == 22, "bunker row %d wrong width" % r)
+		for c in range(22):
+			out[r * 22 + c] = 1 if s[c] == "1" else 0
+	return out

--- a/godot/scripts/invaders/core/invaders_state.gd
+++ b/godot/scripts/invaders/core/invaders_state.gd
@@ -96,15 +96,15 @@ var _dive_rng: RandomNumberGenerator   # reserved; not consumed in v1
 
 static func create(game_seed: int, cfg: InvadersConfig, lvl: InvadersLevel) -> Self:
 	# Tunneling cap (acceptance #12): the fastest moving thing per sub-step
-	# must travel less than the smallest collidable feature.
+	# must travel less than the smallest *broad-phase* collidable feature.
+	# Bunker cells (2 px) are explicitly excluded — bunker hits use a
+	# cell-range AABB scan, not point sampling, so cell size doesn't matter.
+	# What we guard against: bullets skipping past the *enemy* AABB or the
+	# *player* AABB on a single sub-step.
 	var sub_dt_s: float = float(cfg.sub_step_ms) / 1000.0
 	var max_speed: float = maxf(cfg.player_bullet_speed, cfg.enemy_bullet_speed)
 	var step_dist: float = max_speed * sub_dt_s
-	var min_feature: float = minf(2.0 * cfg.enemy_hy,
-			minf(cfg.cell_h,
-			minf(cfg.player_h,
-			minf(cfg.bunker_cell_h,
-			cfg.player_bullet_h))))
+	var min_feature: float = minf(2.0 * cfg.enemy_hy, cfg.player_h)
 	if step_dist >= min_feature:
 		push_error("InvadersGameState.create: tunneling cap violated — max bullet step %f >= min feature %f. Reduce bullet speeds or sub_step_ms." \
 				% [step_dist, min_feature])

--- a/godot/scripts/invaders/core/invaders_state.gd
+++ b/godot/scripts/invaders/core/invaders_state.gd
@@ -1,0 +1,645 @@
+extends RefCounted
+## InvadersGameState — pure formation/bullet/bunker/UFO rules. No Node,
+## no signals. Architecture rule: tick() returns bool indicating change;
+## scene-side observes via snapshot diff (no signals from core).
+##
+## Snapshot version 1 (see snapshot_schema in Dev plan):
+##   - `divers: []` and `rng_dive` are reserved for the Galaga-style dive
+##     follow-up PR. v1 code never reads or writes them past initialization.
+##   - Three sub-RNGs (`_bullet_rng`, `_ufo_rng`, `_dive_rng`) are derived
+##     from master `seed` at create() with disjoint XOR tags. Adding a
+##     consumer in a later PR (e.g. dive) cannot perturb v1 fixtures.
+##
+## Coordinates: world origin top-left, +Y down. Player is at the bottom.
+
+const Self := preload("res://scripts/invaders/core/invaders_state.gd")
+const InvadersConfig := preload("res://scripts/invaders/core/invaders_config.gd")
+const InvadersLevel := preload("res://scripts/invaders/core/invaders_level.gd")
+const Aabb := preload("res://scripts/invaders/core/aabb.gd")
+const Formation := preload("res://scripts/invaders/core/formation.gd")
+const BunkerGrid := preload("res://scripts/invaders/core/bunker_grid.gd")
+const BunkerErosion := preload("res://scripts/invaders/core/bunker_erosion.gd")
+const Ufo := preload("res://scripts/invaders/core/ufo.gd")
+
+const SCHEMA_VERSION: int = 1
+
+# Sub-RNG XOR tags. Bumping these is a BREAKING change to v1 goldens.
+# Chosen as visually-distinct hex constants; values themselves are arbitrary.
+const _RNG_TAG_BULLET: int = 0xB011E7   # "BULLET"-shaped
+const _RNG_TAG_UFO: int = 0x0FF0EF      # "OFFOEF"
+const _RNG_TAG_DIVE: int = 0xD17EFE     # "DIVE"-shaped
+
+
+# --- Config / level ---
+var config: InvadersConfig
+var level: InvadersLevel
+
+# --- Formation state ---
+var live_mask: PackedByteArray   # length rows*cols; 1 = alive
+var enemy_kinds: PackedByteArray # length rows*cols; per-cell kind id
+var formation_ox: float = 0.0
+var formation_oy: float = 0.0
+var formation_dir: int = 1       # +1 right, -1 left
+var formation_step_ms: int = 0
+var formation_last_step_ms: int = 0
+
+# --- Player ---
+var player_x: float = 0.0
+var player_intent_vx: float = 0.0
+var player_alive: bool = true
+var lives: int = 0
+var invuln_until_ms: int = 0
+
+# --- Bullets ---
+# Player has at most one alive at a time.
+var player_bullet_alive: bool = false
+var player_bullet_x: float = 0.0
+var player_bullet_y: float = 0.0
+# Enemy bullets: array of {x,y}.
+var enemy_bullets: Array = []
+
+# --- Bunkers ---
+# bunkers[i] is a BunkerGrid; their world top-left positions are derived
+# from config (evenly spaced). Stored alongside for snapshot fidelity.
+var bunkers: Array = []
+var bunker_origins: Array = []   # Array[Vector2]; aligned with `bunkers`.
+
+# --- Wave / score ---
+var wave: int = 1
+var score: int = 0
+
+# --- UFO ---
+var ufo_alive: bool = false
+var ufo_x: float = 0.0
+var ufo_dir: int = 1
+var ufo_spawn_ms: int = 0
+var last_ufo_spawn_ms: int = 0
+
+# --- Reserved for invaders-dive ---
+var divers: Array = []   # Always [] in v1; dive PR populates without bumping version.
+
+# --- Time ---
+var last_tick_ms: int = 0
+var initialized_clock: bool = false
+var sub_step_accum_ms: int = 0
+# Accumulator for formation cadence; refilled each sub-step by dt_ms.
+var formation_step_ms_accum: int = 0
+
+# --- RNGs ---
+var _master_seed: int = 0
+var _bullet_rng: RandomNumberGenerator
+var _ufo_rng: RandomNumberGenerator
+var _dive_rng: RandomNumberGenerator   # reserved; not consumed in v1
+
+
+# ---------------- Construction ----------------
+
+static func create(game_seed: int, cfg: InvadersConfig, lvl: InvadersLevel) -> Self:
+	# Tunneling cap (acceptance #12): the fastest moving thing per sub-step
+	# must travel less than the smallest collidable feature.
+	var sub_dt_s: float = float(cfg.sub_step_ms) / 1000.0
+	var max_speed: float = maxf(cfg.player_bullet_speed, cfg.enemy_bullet_speed)
+	var step_dist: float = max_speed * sub_dt_s
+	var min_feature: float = minf(2.0 * cfg.enemy_hy,
+			minf(cfg.cell_h,
+			minf(cfg.player_h,
+			minf(cfg.bunker_cell_h,
+			cfg.player_bullet_h))))
+	if step_dist >= min_feature:
+		push_error("InvadersGameState.create: tunneling cap violated — max bullet step %f >= min feature %f. Reduce bullet speeds or sub_step_ms." \
+				% [step_dist, min_feature])
+		return null
+
+	var s: Self = Self.new()
+	s.config = cfg
+	s.level = lvl
+	s._master_seed = game_seed
+	s._bullet_rng = _make_rng(game_seed, _RNG_TAG_BULLET)
+	s._ufo_rng = _make_rng(game_seed, _RNG_TAG_UFO)
+	s._dive_rng = _make_rng(game_seed, _RNG_TAG_DIVE)
+
+	# Formation: all alive, kinds set per-row.
+	var n: int = cfg.rows * cfg.cols
+	s.live_mask = PackedByteArray()
+	s.live_mask.resize(n)
+	s.enemy_kinds = PackedByteArray()
+	s.enemy_kinds.resize(n)
+	for r in range(cfg.rows):
+		var kind: int = lvl.row_kinds[r] if r < lvl.row_kinds.size() else 0
+		for c in range(cfg.cols):
+			s.live_mask[r * cfg.cols + c] = 1
+			s.enemy_kinds[r * cfg.cols + c] = kind
+	s.formation_ox = cfg.formation_start_x
+	s.formation_oy = cfg.formation_start_y
+	s.formation_dir = 1
+	s.formation_step_ms = cfg.step_ms_init
+	s.formation_last_step_ms = 0
+
+	# Player.
+	s.player_x = cfg.world_w * 0.5
+	s.lives = cfg.lives_start
+	s.player_alive = true
+	s.invuln_until_ms = 0
+
+	# Bunkers: equally spaced across the world width.
+	s.bunkers = []
+	s.bunker_origins = []
+	var bunker_world_w: float = lvl.bunker_w_cells * cfg.bunker_cell_w
+	var bunker_world_h: float = lvl.bunker_h_cells * cfg.bunker_cell_h
+	# Total free space = world_w - count * bunker_world_w; gaps are evenly
+	# distributed (count+1 gaps, including the two outer margins).
+	var total_w: float = cfg.bunker_count * bunker_world_w
+	var gap: float = (cfg.world_w - total_w) / float(cfg.bunker_count + 1)
+	for i in range(cfg.bunker_count):
+		var ox: float = gap + i * (bunker_world_w + gap)
+		var oy: float = cfg.bunker_y - bunker_world_h * 0.5
+		s.bunkers.append(BunkerGrid.create(lvl.bunker_w_cells, lvl.bunker_h_cells, lvl.bunker_pattern))
+		s.bunker_origins.append(Vector2(ox, oy))
+
+	s.score = 0
+	s.wave = 1
+	return s
+
+
+static func _make_rng(seed_int: int, tag: int) -> RandomNumberGenerator:
+	# Derive a sub-RNG by XOR-tagging the master seed. Each consumer is
+	# isolated: adding a new sub-RNG cannot perturb existing streams.
+	var r: RandomNumberGenerator = RandomNumberGenerator.new()
+	r.seed = seed_int ^ tag
+	return r
+
+
+# ---------------- Public API ----------------
+
+func set_player_intent(velocity_x: float) -> void:
+	player_intent_vx = clampf(velocity_x, -config.player_max_speed_px_s, config.player_max_speed_px_s)
+
+
+func fire() -> bool:
+	if not player_alive:
+		return false
+	if player_bullet_alive:
+		return false
+	# Spawn at player's top-center.
+	player_bullet_alive = true
+	player_bullet_x = player_x
+	player_bullet_y = config.player_y - config.player_h * 0.5 - config.player_bullet_h * 0.5
+	return true
+
+
+func is_game_over() -> bool:
+	return lives <= 0 or _formation_reached_player()
+
+
+func current_wave() -> int:
+	return wave
+
+
+func set_last_tick(now_ms: int) -> void:
+	# Shift internal clock without simulating. Resets the formation step
+	# accumulator so a long pause doesn't burst-step on resume.
+	last_tick_ms = now_ms
+	initialized_clock = true
+	# Re-anchor formation pacing to "now".
+	formation_last_step_ms = now_ms
+
+
+func tick(now_ms: int) -> bool:
+	if is_game_over():
+		# Even when game-over we still want to honour set_last_tick semantics,
+		# but no simulation runs.
+		last_tick_ms = now_ms
+		initialized_clock = true
+		return false
+	if not initialized_clock:
+		last_tick_ms = now_ms
+		initialized_clock = true
+		formation_last_step_ms = now_ms
+	var elapsed: int = now_ms - last_tick_ms
+	if elapsed <= 0:
+		return false
+	var changed: bool = false
+	var sub: int = config.sub_step_ms
+	var cap: int = config.max_sub_steps_per_tick
+	sub_step_accum_ms += elapsed
+	last_tick_ms = now_ms
+	var iters: int = 0
+	while sub_step_accum_ms >= sub and iters < cap:
+		if _sub_step(sub, now_ms - sub_step_accum_ms + sub):
+			changed = true
+		sub_step_accum_ms -= sub
+		iters += 1
+		if is_game_over():
+			break
+	# Drain leftover (drop frames) to avoid unbounded backlog.
+	if sub_step_accum_ms >= sub:
+		sub_step_accum_ms = sub_step_accum_ms % sub
+	return changed
+
+
+# ---------------- Internal: sub-step ----------------
+
+func _sub_step(dt_ms: int, _at_ms: int) -> bool:
+	var dt_s: float = float(dt_ms) / 1000.0
+	var changed: bool = false
+
+	# 1. Player horizontal motion.
+	var new_px: float = player_x + player_intent_vx * dt_s
+	# Clamp to world (player half-width on each side).
+	var phw: float = config.player_w * 0.5
+	new_px = clampf(new_px, phw, config.world_w - phw)
+	if not is_equal_approx(new_px, player_x):
+		player_x = new_px
+		changed = true
+
+	# 2. Player bullet motion + collisions.
+	if player_bullet_alive:
+		player_bullet_y -= config.player_bullet_speed * dt_s
+		if player_bullet_y < 0.0:
+			player_bullet_alive = false
+			changed = true
+		else:
+			# Check vs enemies.
+			if _player_bullet_vs_enemies():
+				changed = true
+			elif _player_bullet_vs_ufo():
+				changed = true
+			elif _player_bullet_vs_bunkers():
+				changed = true
+		if player_bullet_alive:
+			changed = true   # moved
+
+	# 3. Enemy bullets motion + collisions.
+	if not enemy_bullets.is_empty():
+		var i: int = 0
+		while i < enemy_bullets.size():
+			var b: Dictionary = enemy_bullets[i]
+			var ny: float = float(b["y"]) + config.enemy_bullet_speed * dt_s
+			if ny > config.world_h:
+				enemy_bullets.remove_at(i)
+				changed = true
+				continue
+			b["y"] = ny
+			enemy_bullets[i] = b
+			# vs bunkers.
+			if _enemy_bullet_vs_bunkers(i):
+				changed = true
+				continue   # bullet consumed; index now points to next
+			# vs player.
+			if _enemy_bullet_vs_player(i):
+				changed = true
+				continue
+			i += 1
+			changed = true   # moved
+
+	# 4. Formation step (cadence based on accumulated time).
+	#    We bill the sub-step's dt against the formation's step_ms accumulator.
+	formation_step_ms_accum += dt_ms
+	if formation_step_ms_accum >= formation_step_ms:
+		formation_step_ms_accum -= formation_step_ms
+		_step_formation()
+		# Recompute step_ms after possible enemy deaths since last step.
+		var live: int = Formation.live_count(live_mask)
+		formation_step_ms = Formation.step_ms_for_population(live, config.rows * config.cols,
+				config.step_ms_init, config.min_step_ms)
+		changed = true
+
+	# 5. Enemy fire chance.
+	if enemy_bullets.size() < _max_enemy_bullets() \
+			and _bullet_rng.randf() < config.enemy_fire_p_init:
+		if _spawn_enemy_bullet():
+			changed = true
+
+	# 6. UFO lifecycle.
+	if _step_ufo(dt_s, dt_ms):
+		changed = true
+
+	# 7. Invulnerability tick.
+	if invuln_until_ms > 0:
+		invuln_until_ms = maxi(0, invuln_until_ms - dt_ms)
+
+	# 8. Wave clear?
+	if Formation.live_count(live_mask) == 0:
+		_advance_wave()
+		changed = true
+
+	return changed
+
+
+# ---------------- Internal: formation ----------------
+
+func _step_formation() -> void:
+	# Tentatively shift origin horizontally; check edge bounce.
+	var tentative_ox: float = formation_ox + formation_dir * config.step_dx
+	var bx_after: Vector2 = Formation.bounds_x(live_mask, config.rows, config.cols,
+			tentative_ox, formation_oy, config.cell_w, config.cell_h, config.enemy_hx)
+	if bx_after.x == -INF:
+		return  # no live enemies (shouldn't happen here)
+	if bx_after.x < 0.0 or bx_after.y > config.world_w:
+		# Edge bounce: reverse + drop. Do NOT also apply the horizontal
+		# step on the bounce frame (matches arcade behaviour).
+		formation_dir = -formation_dir
+		formation_oy += config.step_dy
+	else:
+		formation_ox = tentative_ox
+
+
+# ---------------- Internal: bullets ----------------
+
+func _player_bullet_vs_enemies() -> bool:
+	# Iterate cells; first hit wins. Bullet is consumed.
+	for r in range(config.rows):
+		for c in range(config.cols):
+			if live_mask[r * config.cols + c] != 1:
+				continue
+			var ecx: float = formation_ox + c * config.cell_w + config.cell_w * 0.5
+			var ecy: float = formation_oy + r * config.cell_h + config.cell_h * 0.5
+			if Aabb.overlaps(player_bullet_x, player_bullet_y,
+					config.player_bullet_w * 0.5, config.player_bullet_h * 0.5,
+					ecx, ecy, config.enemy_hx, config.enemy_hy):
+				live_mask[r * config.cols + c] = 0
+				var kind_idx: int = enemy_kinds[r * config.cols + c]
+				var val: int = level.row_values[kind_idx] if kind_idx < level.row_values.size() else 10
+				score += val
+				player_bullet_alive = false
+				return true
+	return false
+
+
+func _player_bullet_vs_ufo() -> bool:
+	if not ufo_alive:
+		return false
+	if Aabb.overlaps(player_bullet_x, player_bullet_y,
+			config.player_bullet_w * 0.5, config.player_bullet_h * 0.5,
+			ufo_x, config.ufo_y, config.ufo_w * 0.5, config.ufo_h * 0.5):
+		score += Ufo.pick_score(_ufo_rng)
+		ufo_alive = false
+		player_bullet_alive = false
+		return true
+	return false
+
+
+func _player_bullet_vs_bunkers() -> bool:
+	for i in range(bunkers.size()):
+		var bg: BunkerGrid = bunkers[i]
+		var origin: Vector2 = bunker_origins[i]
+		var hit: Dictionary = {}
+		if bg.aabb_hit(origin.x, origin.y, config.bunker_cell_w, config.bunker_cell_h,
+				player_bullet_x, player_bullet_y,
+				config.player_bullet_w * 0.5, config.player_bullet_h * 0.5, hit):
+			bg.apply_stamp(BunkerErosion.player_up_stamp(),
+					BunkerErosion.PLAYER_UP_W, BunkerErosion.PLAYER_UP_H,
+					int(hit["cx"]), int(hit["cy"]),
+					BunkerErosion.PLAYER_UP_ANCHOR_SX, BunkerErosion.PLAYER_UP_ANCHOR_SY)
+			player_bullet_alive = false
+			return true
+	return false
+
+
+func _enemy_bullet_vs_bunkers(idx: int) -> bool:
+	var b: Dictionary = enemy_bullets[idx]
+	for i in range(bunkers.size()):
+		var bg: BunkerGrid = bunkers[i]
+		var origin: Vector2 = bunker_origins[i]
+		var hit: Dictionary = {}
+		if bg.aabb_hit(origin.x, origin.y, config.bunker_cell_w, config.bunker_cell_h,
+				float(b["x"]), float(b["y"]),
+				config.enemy_bullet_w * 0.5, config.enemy_bullet_h * 0.5, hit):
+			bg.apply_stamp(BunkerErosion.enemy_down_stamp(),
+					BunkerErosion.ENEMY_DOWN_W, BunkerErosion.ENEMY_DOWN_H,
+					int(hit["cx"]), int(hit["cy"]),
+					BunkerErosion.ENEMY_DOWN_ANCHOR_SX, BunkerErosion.ENEMY_DOWN_ANCHOR_SY)
+			enemy_bullets.remove_at(idx)
+			return true
+	return false
+
+
+func _enemy_bullet_vs_player(idx: int) -> bool:
+	if not player_alive or invuln_until_ms > 0:
+		return false
+	var b: Dictionary = enemy_bullets[idx]
+	if Aabb.overlaps(float(b["x"]), float(b["y"]),
+			config.enemy_bullet_w * 0.5, config.enemy_bullet_h * 0.5,
+			player_x, config.player_y,
+			config.player_w * 0.5, config.player_h * 0.5):
+		enemy_bullets.remove_at(idx)
+		_player_hit()
+		return true
+	return false
+
+
+func _player_hit() -> void:
+	lives -= 1
+	if lives <= 0:
+		player_alive = false
+		return
+	# Brief invulnerability + clear all enemy bullets currently on screen.
+	invuln_until_ms = config.invuln_ms
+	enemy_bullets.clear()
+	player_bullet_alive = false
+
+
+# ---------------- Internal: enemy bullets ----------------
+
+func _max_enemy_bullets() -> int:
+	# +1 every `wave_step` waves above wave 1.
+	var bonus: int = ((wave - 1) / config.enemy_bullets_wave_step) * config.enemy_bullets_per_wave
+	return config.enemy_bullets_max_init + bonus
+
+
+func _spawn_enemy_bullet() -> bool:
+	var seed_col: int = _bullet_rng.randi()
+	var col: int = Formation.find_firing_column(live_mask, config.rows, config.cols, seed_col)
+	if col < 0:
+		return false
+	var row: int = Formation.bottom_row(live_mask, config.rows, config.cols, col)
+	if row < 0:
+		return false
+	var ecx: float = formation_ox + col * config.cell_w + config.cell_w * 0.5
+	var ecy: float = formation_oy + row * config.cell_h + config.cell_h * 0.5
+	# Spawn just below the bottom of the firing enemy.
+	var bx: float = ecx
+	var by: float = ecy + config.enemy_hy + config.enemy_bullet_h * 0.5 + 0.001
+	enemy_bullets.append({"x": bx, "y": by})
+	return true
+
+
+# ---------------- Internal: UFO ----------------
+
+func _step_ufo(dt_s: float, dt_ms: int) -> bool:
+	var changed: bool = false
+	if ufo_alive:
+		ufo_x += ufo_dir * config.ufo_speed * dt_s
+		# Off-screen?
+		var hw: float = config.ufo_w * 0.5
+		if (ufo_dir > 0 and ufo_x - hw > config.world_w) \
+				or (ufo_dir < 0 and ufo_x + hw < 0.0):
+			ufo_alive = false
+			last_ufo_spawn_ms = last_tick_ms
+		changed = true
+	else:
+		# Note: should_spawn uses the master "now" (last_tick_ms is fine).
+		if Ufo.should_spawn(_ufo_rng, last_tick_ms, last_ufo_spawn_ms,
+				config.ufo_interval_ms_init, config.ufo_jitter_ms):
+			ufo_alive = true
+			ufo_dir = Ufo.pick_direction(_ufo_rng)
+			ufo_spawn_ms = last_tick_ms
+			ufo_x = -config.ufo_w * 0.5 if ufo_dir > 0 else config.world_w + config.ufo_w * 0.5
+			changed = true
+	return changed
+
+
+# ---------------- Internal: wave / loss ----------------
+
+func _formation_reached_player() -> bool:
+	var by: Vector2 = Formation.bounds_y(live_mask, config.rows, config.cols,
+			formation_ox, formation_oy, config.cell_w, config.cell_h, config.enemy_hy)
+	if by.x == -INF:
+		return false
+	# Player's top edge is player_y - h/2; if any enemy AABB-bottom >= it, loss.
+	var player_top: float = config.player_y - config.player_h * 0.5
+	return by.y >= player_top
+
+
+func _advance_wave() -> void:
+	wave += 1
+	# Reset formation: all alive, higher start, faster.
+	var n: int = config.rows * config.cols
+	live_mask = PackedByteArray()
+	live_mask.resize(n)
+	for r in range(config.rows):
+		var kind: int = level.row_kinds[r] if r < level.row_kinds.size() else 0
+		for c in range(config.cols):
+			live_mask[r * config.cols + c] = 1
+			enemy_kinds[r * config.cols + c] = kind
+	# New start_y = clamp(start_y - drop, min, start_y).
+	var ny: float = maxf(config.wave_min_start_y,
+			config.formation_start_y - (wave - 1) * config.wave_drop_y)
+	formation_oy = ny
+	formation_ox = config.formation_start_x
+	formation_dir = 1
+	# Speed: shrink step_ms_init by factor each wave.
+	var ms: float = float(config.step_ms_init) * pow(config.wave_speed_factor, wave - 1)
+	formation_step_ms = maxi(config.min_step_ms, int(round(ms)))
+	formation_step_ms_accum = 0
+	# Active UFO is force-removed at wave change (acceptance #10).
+	ufo_alive = false
+	# Bullets are kept; gameplay-wise it's fine and avoids surprising the player.
+
+
+# ---------------- Snapshot / restore ----------------
+
+func snapshot() -> Dictionary:
+	# Deep copy of mutable arrays so caller can't mutate our state.
+	var lm: PackedByteArray = PackedByteArray()
+	lm.resize(live_mask.size())
+	for i in range(live_mask.size()):
+		lm[i] = live_mask[i]
+	var ek: PackedByteArray = PackedByteArray()
+	ek.resize(enemy_kinds.size())
+	for i in range(enemy_kinds.size()):
+		ek[i] = enemy_kinds[i]
+	var ebs: Array = []
+	for b in enemy_bullets:
+		ebs.append({"x": float(b["x"]), "y": float(b["y"])})
+	var bgs: Array = []
+	for bg in bunkers:
+		bgs.append(bg.snapshot_cells())
+	var ufo_obj: Variant = null
+	if ufo_alive:
+		ufo_obj = {"x": ufo_x, "dir": ufo_dir, "spawn_ms": ufo_spawn_ms}
+	return {
+		"version": SCHEMA_VERSION,
+		"wave": wave,
+		"score": score,
+		"lives": lives,
+		"formation": {
+			"ox": formation_ox,
+			"oy": formation_oy,
+			"dir": formation_dir,
+			"step_ms": formation_step_ms,
+			"last_step_ms": formation_last_step_ms,
+		},
+		"enemies": lm,
+		"enemy_kinds": ek,
+		"player": {
+			"x": player_x,
+			"alive": player_alive,
+			"invuln_until_ms": invuln_until_ms,
+		},
+		"player_bullet": {
+			"x": player_bullet_x,
+			"y": player_bullet_y,
+			"alive": player_bullet_alive,
+		},
+		"enemy_bullets": ebs,
+		"bunkers": bgs,
+		"ufo": ufo_obj,
+		"last_ufo_spawn_ms": last_ufo_spawn_ms,
+		"divers": [],
+		"rng_master": _master_seed,
+		"rng_bullet": int(_bullet_rng.state),
+		"rng_ufo": int(_ufo_rng.state),
+		"rng_dive": int(_dive_rng.state),
+	}
+
+
+static func from_snapshot(snap: Dictionary, cfg: InvadersConfig, lvl: InvadersLevel) -> Self:
+	var s: Self = create(int(snap.get("rng_master", 0)), cfg, lvl)
+	if s == null:
+		return null
+	s.wave = int(snap["wave"])
+	s.score = int(snap["score"])
+	s.lives = int(snap["lives"])
+	var f: Dictionary = snap["formation"]
+	s.formation_ox = float(f["ox"])
+	s.formation_oy = float(f["oy"])
+	s.formation_dir = int(f["dir"])
+	s.formation_step_ms = int(f["step_ms"])
+	s.formation_last_step_ms = int(f["last_step_ms"])
+	# Restore mutable buffers.
+	var lm: PackedByteArray = snap["enemies"]
+	s.live_mask = PackedByteArray()
+	s.live_mask.resize(lm.size())
+	for i in range(lm.size()):
+		s.live_mask[i] = lm[i]
+	var ek: PackedByteArray = snap["enemy_kinds"]
+	s.enemy_kinds = PackedByteArray()
+	s.enemy_kinds.resize(ek.size())
+	for i in range(ek.size()):
+		s.enemy_kinds[i] = ek[i]
+	var p: Dictionary = snap["player"]
+	s.player_x = float(p["x"])
+	s.player_alive = bool(p["alive"])
+	s.invuln_until_ms = int(p["invuln_until_ms"])
+	var pb: Dictionary = snap["player_bullet"]
+	s.player_bullet_x = float(pb["x"])
+	s.player_bullet_y = float(pb["y"])
+	s.player_bullet_alive = bool(pb["alive"])
+	s.enemy_bullets = []
+	for b in snap["enemy_bullets"]:
+		s.enemy_bullets.append({"x": float(b["x"]), "y": float(b["y"])})
+	# Bunkers. Re-derive bunker_origins via create() — they are deterministic
+	# from cfg + count, and the create() call above already set them.
+	var bgs: Array = snap["bunkers"]
+	s.bunkers = []
+	for i in range(bgs.size()):
+		s.bunkers.append(BunkerGrid.from_snapshot(lvl.bunker_w_cells, lvl.bunker_h_cells, bgs[i]))
+	# UFO.
+	if snap["ufo"] == null:
+		s.ufo_alive = false
+	else:
+		var u: Dictionary = snap["ufo"]
+		s.ufo_alive = true
+		s.ufo_x = float(u["x"])
+		s.ufo_dir = int(u["dir"])
+		s.ufo_spawn_ms = int(u["spawn_ms"])
+	s.last_ufo_spawn_ms = int(snap["last_ufo_spawn_ms"])
+	s.divers = []  # reserved; v1 always []
+	# RNG states. We use master_seed in create() to set initial states; now
+	# overwrite with the saved states so randomness picks up from the exact
+	# point of the snapshot.
+	s._bullet_rng.state = int(snap.get("rng_bullet", s._bullet_rng.state))
+	s._ufo_rng.state = int(snap.get("rng_ufo", s._ufo_rng.state))
+	s._dive_rng.state = int(snap.get("rng_dive", s._dive_rng.state))
+	return s

--- a/godot/scripts/invaders/core/ufo.gd
+++ b/godot/scripts/invaders/core/ufo.gd
@@ -1,0 +1,32 @@
+extends RefCounted
+## ufo.gd — pure helpers for the UFO bonus saucer. State (alive flag,
+## position, direction, last-spawn timestamp) lives in InvadersGameState;
+## these are stateless functions.
+##
+## Score table is the deterministic [50,100,150,300] (Dev plan §UFO).
+## Picked by `_ufo_rng.randi() % 4` so it is reproducible from the seed.
+
+const SCORE_TABLE: Array = [50, 100, 150, 300]
+
+
+## Should we spawn a UFO right now? Called once per fixed sub-step.
+## Spawns iff:
+##   - No UFO is currently alive (caller's responsibility to check).
+##   - Time since the last spawn (or game start) ≥ ufo_interval_ms +
+##     jitter, where jitter ∈ [-half, +half] drawn from `rng`.
+static func should_spawn(rng: RandomNumberGenerator, now_ms: int,
+		last_spawn_ms: int, interval_ms: int, jitter_ms: int) -> bool:
+	# Jitter: uniform integer in [-jitter_ms/2, +jitter_ms/2].
+	var jitter: int = (rng.randi() % (jitter_ms + 1)) - (jitter_ms / 2)
+	return now_ms - last_spawn_ms >= interval_ms + jitter
+
+
+## Pick the score awarded for hitting the UFO. Indexed by `rng.randi() % 4`.
+static func pick_score(rng: RandomNumberGenerator) -> int:
+	return SCORE_TABLE[rng.randi() % SCORE_TABLE.size()]
+
+
+## Pick spawn direction: -1 (right→left, spawned at right edge) or +1
+## (left→right, spawned at left edge). Selected by low bit of an rng draw.
+static func pick_direction(rng: RandomNumberGenerator) -> int:
+	return -1 if (rng.randi() & 1) == 1 else 1

--- a/godot/tests/unit/invaders/test_bunker_erosion.gd
+++ b/godot/tests/unit/invaders/test_bunker_erosion.gd
@@ -1,0 +1,53 @@
+extends GutTest
+## bunker_erosion.gd — stamp constants and shape.
+
+const BunkerErosion := preload("res://scripts/invaders/core/bunker_erosion.gd")
+
+
+func test_player_up_stamp_dimensions() -> void:
+	var s: PackedByteArray = BunkerErosion.player_up_stamp()
+	assert_eq(s.size(), BunkerErosion.PLAYER_UP_W * BunkerErosion.PLAYER_UP_H)
+	assert_eq(BunkerErosion.PLAYER_UP_W, 5)
+	assert_eq(BunkerErosion.PLAYER_UP_H, 3)
+
+
+func test_player_up_stamp_pattern() -> void:
+	# ".XXX." → 0,1,1,1,0
+	# "XXXXX" → 1,1,1,1,1
+	# "XXXXX" → 1,1,1,1,1
+	var s: PackedByteArray = BunkerErosion.player_up_stamp()
+	# Row 0
+	assert_eq(s[0], 0); assert_eq(s[1], 1); assert_eq(s[2], 1); assert_eq(s[3], 1); assert_eq(s[4], 0)
+	# Row 1
+	for i in range(5):
+		assert_eq(s[5 + i], 1)
+	# Row 2
+	for i in range(5):
+		assert_eq(s[10 + i], 1)
+
+
+func test_enemy_down_stamp_dimensions() -> void:
+	var s: PackedByteArray = BunkerErosion.enemy_down_stamp()
+	assert_eq(s.size(), BunkerErosion.ENEMY_DOWN_W * BunkerErosion.ENEMY_DOWN_H)
+	assert_eq(BunkerErosion.ENEMY_DOWN_W, 5)
+	assert_eq(BunkerErosion.ENEMY_DOWN_H, 4)
+
+
+func test_enemy_down_stamp_pattern() -> void:
+	# Row 0 "XXXXX", row 1 "XXXXX", row 2 "X...X", row 3 ".X.X."
+	var s: PackedByteArray = BunkerErosion.enemy_down_stamp()
+	for i in range(5):
+		assert_eq(s[i], 1, "row 0 cell %d" % i)
+		assert_eq(s[5 + i], 1, "row 1 cell %d" % i)
+	# Row 2: X...X → 1,0,0,0,1
+	assert_eq(s[10], 1); assert_eq(s[11], 0); assert_eq(s[12], 0); assert_eq(s[13], 0); assert_eq(s[14], 1)
+	# Row 3: .X.X. → 0,1,0,1,0
+	assert_eq(s[15], 0); assert_eq(s[16], 1); assert_eq(s[17], 0); assert_eq(s[18], 1); assert_eq(s[19], 0)
+
+
+func test_anchor_constants() -> void:
+	# Player-up anchors at bottom-center; enemy-down at top-center.
+	assert_eq(BunkerErosion.PLAYER_UP_ANCHOR_SX, 2)
+	assert_eq(BunkerErosion.PLAYER_UP_ANCHOR_SY, 2)
+	assert_eq(BunkerErosion.ENEMY_DOWN_ANCHOR_SX, 2)
+	assert_eq(BunkerErosion.ENEMY_DOWN_ANCHOR_SY, 0)

--- a/godot/tests/unit/invaders/test_bunker_erosion.gd.uid
+++ b/godot/tests/unit/invaders/test_bunker_erosion.gd.uid
@@ -1,0 +1,1 @@
+uid://ff6exia6ejq8

--- a/godot/tests/unit/invaders/test_bunker_grid.gd
+++ b/godot/tests/unit/invaders/test_bunker_grid.gd
@@ -1,0 +1,124 @@
+extends GutTest
+## bunker_grid.gd — get/clear/aabb_hit/snapshot.
+
+const BunkerGrid := preload("res://scripts/invaders/core/bunker_grid.gd")
+
+
+func _solid_pattern(w: int, h: int) -> PackedByteArray:
+	var p: PackedByteArray = PackedByteArray()
+	p.resize(w * h)
+	for i in range(p.size()):
+		p[i] = 1
+	return p
+
+
+func test_create_copies_pattern() -> void:
+	var p: PackedByteArray = _solid_pattern(4, 3)
+	var bg = BunkerGrid.create(4, 3, p)
+	assert_eq(bg.w, 4)
+	assert_eq(bg.h, 3)
+	# Mutate source — shouldn't affect grid.
+	p[0] = 0
+	assert_eq(bg.get_cell(0, 0), 1)
+
+
+func test_clear_cell_in_bounds() -> void:
+	var bg = BunkerGrid.create(4, 3, _solid_pattern(4, 3))
+	bg.clear_cell(2, 1)
+	assert_eq(bg.get_cell(2, 1), 0)
+	assert_eq(bg.get_cell(2, 0), 1)
+
+
+func test_clear_cell_out_of_bounds_noop() -> void:
+	var bg = BunkerGrid.create(4, 3, _solid_pattern(4, 3))
+	bg.clear_cell(99, 99)
+	bg.clear_cell(-1, 0)
+	# Original cells intact.
+	assert_eq(bg.get_cell(0, 0), 1)
+
+
+func test_apply_stamp_clears_matching_cells() -> void:
+	# Solid 5x5 grid; stamp = bottom-row 1's, anchor at center bottom.
+	var bg = BunkerGrid.create(5, 5, _solid_pattern(5, 5))
+	var stamp: PackedByteArray = PackedByteArray()
+	stamp.resize(3 * 1)
+	stamp[0] = 1; stamp[1] = 1; stamp[2] = 1
+	# Anchor sx=1 (center) sy=0 (top of stamp). Apply at grid (2, 4).
+	var cleared: int = bg.apply_stamp(stamp, 3, 1, 2, 4, 1, 0)
+	assert_eq(cleared, 3)
+	# Expect (1,4), (2,4), (3,4) cleared.
+	assert_eq(bg.get_cell(1, 4), 0)
+	assert_eq(bg.get_cell(2, 4), 0)
+	assert_eq(bg.get_cell(3, 4), 0)
+	# (0,4) and (4,4) untouched.
+	assert_eq(bg.get_cell(0, 4), 1)
+	assert_eq(bg.get_cell(4, 4), 1)
+
+
+func test_apply_stamp_clips_out_of_bounds() -> void:
+	var bg = BunkerGrid.create(3, 3, _solid_pattern(3, 3))
+	# 5-wide stamp centered at col 0 → 2 cells go off the left edge.
+	var stamp: PackedByteArray = PackedByteArray()
+	stamp.resize(5)
+	for i in range(5):
+		stamp[i] = 1
+	var cleared: int = bg.apply_stamp(stamp, 5, 1, 0, 0, 2, 0)
+	# Only (0,0), (1,0), (2,0) actually exist → 3 cleared.
+	assert_eq(cleared, 3)
+
+
+func test_apply_stamp_already_empty_doesnt_count() -> void:
+	var bg = BunkerGrid.create(3, 3, _solid_pattern(3, 3))
+	bg.clear_cell(1, 1)
+	var stamp: PackedByteArray = PackedByteArray()
+	stamp.resize(1)
+	stamp[0] = 1
+	# Stamp the already-cleared cell.
+	var cleared: int = bg.apply_stamp(stamp, 1, 1, 1, 1, 0, 0)
+	assert_eq(cleared, 0)
+
+
+func test_aabb_hit_finds_filled_cell() -> void:
+	# 4x4 solid grid; cells 2x2; bunker origin at (10, 20).
+	# AABB at (12, 22) with extents 1,1 → covers cells (1,1) area. Should hit.
+	var bg = BunkerGrid.create(4, 4, _solid_pattern(4, 4))
+	var out: Dictionary = {}
+	var hit: bool = bg.aabb_hit(10.0, 20.0, 2.0, 2.0, 12.0, 22.0, 1.0, 1.0, out)
+	assert_true(hit)
+	# We expect the first filled cell scanned to be reported. Just verify
+	# the (cx,cy) returned is in-range.
+	assert_true(out.has("cx"))
+	assert_true(int(out["cx"]) >= 0 and int(out["cx"]) < 4)
+
+
+func test_aabb_hit_misses_when_all_empty() -> void:
+	var bg = BunkerGrid.create(4, 4, _solid_pattern(4, 4))
+	# Clear all cells in the area.
+	for cx in range(4):
+		for cy in range(4):
+			bg.clear_cell(cx, cy)
+	var out: Dictionary = {}
+	assert_false(bg.aabb_hit(10.0, 20.0, 2.0, 2.0, 12.0, 22.0, 1.0, 1.0, out))
+
+
+func test_aabb_hit_outside_grid_returns_false() -> void:
+	var bg = BunkerGrid.create(4, 4, _solid_pattern(4, 4))
+	var out: Dictionary = {}
+	# AABB far away from bunker (origin 10,20; size 8x8) → completely off.
+	assert_false(bg.aabb_hit(10.0, 20.0, 2.0, 2.0, 100.0, 100.0, 1.0, 1.0, out))
+
+
+func test_snapshot_round_trip() -> void:
+	var bg = BunkerGrid.create(3, 3, _solid_pattern(3, 3))
+	bg.clear_cell(1, 1)
+	bg.clear_cell(0, 2)
+	var snap: PackedByteArray = bg.snapshot_cells()
+	var bg2 = BunkerGrid.from_snapshot(3, 3, snap)
+	assert_eq(bg2.w, 3)
+	assert_eq(bg2.h, 3)
+	assert_eq(bg2.get_cell(1, 1), 0)
+	assert_eq(bg2.get_cell(0, 2), 0)
+	assert_eq(bg2.get_cell(0, 0), 1)
+	# Mutate original — snapshot copy shouldn't aliase.
+	bg.clear_cell(2, 2)
+	assert_eq(bg2.get_cell(2, 2), 1)

--- a/godot/tests/unit/invaders/test_bunker_grid.gd.uid
+++ b/godot/tests/unit/invaders/test_bunker_grid.gd.uid
@@ -1,0 +1,1 @@
+uid://doeq1cxscxdwa

--- a/godot/tests/unit/invaders/test_formation.gd
+++ b/godot/tests/unit/invaders/test_formation.gd
@@ -1,0 +1,109 @@
+extends GutTest
+## formation.gd — bounds, live count, speed curve, firing column.
+
+const Formation := preload("res://scripts/invaders/core/formation.gd")
+
+
+func _full_mask(rows: int, cols: int) -> PackedByteArray:
+	var m: PackedByteArray = PackedByteArray()
+	m.resize(rows * cols)
+	for i in range(m.size()):
+		m[i] = 1
+	return m
+
+
+func test_bounds_x_full_grid() -> void:
+	# 5x11 grid, cell_w=16, ox=16, enemy_hx=6
+	# Leftmost cell center = 16 + 0*16 + 8 = 24; left edge = 24-6 = 18
+	# Rightmost center = 16 + 10*16 + 8 = 184; right edge = 184+6 = 190
+	var m: PackedByteArray = _full_mask(5, 11)
+	var b: Vector2 = Formation.bounds_x(m, 5, 11, 16.0, 40.0, 16.0, 14.0, 6.0)
+	assert_almost_eq(b.x, 18.0, 1e-6)
+	assert_almost_eq(b.y, 190.0, 1e-6)
+
+
+func test_bounds_x_after_killing_outer_columns() -> void:
+	# Kill all of col 0 and col 10 — leftmost should now be col 1.
+	var m: PackedByteArray = _full_mask(5, 11)
+	for r in range(5):
+		m[r * 11 + 0] = 0
+		m[r * 11 + 10] = 0
+	var b: Vector2 = Formation.bounds_x(m, 5, 11, 16.0, 40.0, 16.0, 14.0, 6.0)
+	# col 1 center = 16 + 16 + 8 = 40; left = 34
+	# col 9 center = 16 + 9*16 + 8 = 168; right = 174
+	assert_almost_eq(b.x, 34.0, 1e-6)
+	assert_almost_eq(b.y, 174.0, 1e-6)
+
+
+func test_bounds_y_full_grid() -> void:
+	var m: PackedByteArray = _full_mask(5, 11)
+	var b: Vector2 = Formation.bounds_y(m, 5, 11, 16.0, 40.0, 16.0, 14.0, 5.0)
+	# row 0 center = 40 + 7 = 47; top = 42
+	# row 4 center = 40 + 4*14 + 7 = 103; bottom = 108
+	assert_almost_eq(b.x, 42.0, 1e-6)
+	assert_almost_eq(b.y, 108.0, 1e-6)
+
+
+func test_bounds_empty_returns_neg_inf() -> void:
+	var m: PackedByteArray = PackedByteArray()
+	m.resize(55)  # all zeros
+	var bx: Vector2 = Formation.bounds_x(m, 5, 11, 0.0, 0.0, 16.0, 14.0, 6.0)
+	assert_eq(bx.x, -INF)
+
+
+func test_live_count() -> void:
+	assert_eq(Formation.live_count(_full_mask(5, 11)), 55)
+	var m: PackedByteArray = _full_mask(5, 11)
+	for i in range(10):
+		m[i] = 0
+	assert_eq(Formation.live_count(m), 45)
+
+
+func test_step_ms_for_population_bounds() -> void:
+	# Full population → step_ms_init.
+	assert_eq(Formation.step_ms_for_population(55, 55, 800, 80), 800)
+	# Single survivor → min_step_ms (1/55 lerp lands close to min).
+	var ms: int = Formation.step_ms_for_population(1, 55, 800, 80)
+	# t = 1/55 ≈ 0.018 → ms ≈ 80 + 0.018*(800-80) ≈ 93.
+	assert_lt(ms, 100)
+	# Zero alive → min_step_ms.
+	assert_eq(Formation.step_ms_for_population(0, 55, 800, 80), 80)
+
+
+func test_step_ms_monotonic() -> void:
+	# Killing enemies one-by-one: step_ms strictly non-increasing.
+	var prev: int = 100000
+	for live in range(55, 0, -1):
+		var ms: int = Formation.step_ms_for_population(live, 55, 800, 80)
+		assert_true(ms <= prev, "step_ms should not increase when population shrinks (live=%d)" % live)
+		prev = ms
+
+
+func test_find_firing_column_skips_empty() -> void:
+	# Mark only column 7 alive. Whatever seed we pass, find_firing_column
+	# must land on 7 (it walks rightward).
+	var m: PackedByteArray = PackedByteArray()
+	m.resize(5 * 11)
+	for r in range(5):
+		m[r * 11 + 7] = 1
+	for seed in range(20):
+		assert_eq(Formation.find_firing_column(m, 5, 11, seed), 7)
+
+
+func test_find_firing_column_no_alive() -> void:
+	var m: PackedByteArray = PackedByteArray()
+	m.resize(55)
+	assert_eq(Formation.find_firing_column(m, 5, 11, 0), -1)
+
+
+func test_bottom_row() -> void:
+	var m: PackedByteArray = _full_mask(5, 11)
+	# Full column → bottom is row 4.
+	assert_eq(Formation.bottom_row(m, 5, 11, 3), 4)
+	# Kill row 4 of col 3 → bottom is row 3.
+	m[4 * 11 + 3] = 0
+	assert_eq(Formation.bottom_row(m, 5, 11, 3), 3)
+	# Kill all of col 3 → -1.
+	for r in range(5):
+		m[r * 11 + 3] = 0
+	assert_eq(Formation.bottom_row(m, 5, 11, 3), -1)

--- a/godot/tests/unit/invaders/test_formation.gd.uid
+++ b/godot/tests/unit/invaders/test_formation.gd.uid
@@ -1,0 +1,1 @@
+uid://c5swmlrgscc2p

--- a/godot/tests/unit/invaders/test_state_collisions.gd
+++ b/godot/tests/unit/invaders/test_state_collisions.gd
@@ -1,0 +1,204 @@
+extends GutTest
+## InvadersGameState — collisions, formation step, wave progression,
+## loss conditions, UFO behaviour.
+
+const State := preload("res://scripts/invaders/core/invaders_state.gd")
+const Cfg := preload("res://scripts/invaders/core/invaders_config.gd")
+const Lvl := preload("res://scripts/invaders/core/invaders_level.gd")
+const Formation := preload("res://scripts/invaders/core/formation.gd")
+
+
+func _cfg() -> Cfg:
+	return Cfg.new()
+
+
+func _lvl() -> Lvl:
+	return Lvl.new()
+
+
+# --- Formation step + edge bounce ---
+
+func test_formation_step_shifts_origin() -> void:
+	var s = State.create(0, _cfg(), _lvl())
+	# Force a step by manipulating the accumulator + step_ms.
+	s.formation_step_ms_accum = s.formation_step_ms
+	var ox_before: float = s.formation_ox
+	s._step_formation()
+	assert_almost_eq(s.formation_ox, ox_before + s.config.step_dx, 1e-6)
+
+
+func test_formation_edge_bounce_reverses_and_drops() -> void:
+	var c: Cfg = _cfg()
+	c.world_w = 100.0
+	c.formation_start_x = 80.0  # Right edge near world.right
+	c.cell_w = 4.0
+	c.cell_h = 4.0
+	c.cols = 5
+	c.rows = 1
+	c.enemy_hx = 1.0
+	c.step_dx = 4.0
+	c.step_dy = 8.0
+	var s = State.create(0, c, _lvl())
+	# Single row of 5 cells: rightmost center = 80 + 4*4 + 2 = 98; right
+	# edge after extents = 99. Step right by 4 → 103 → past world.right.
+	# Must reverse + drop.
+	var oy_before: float = s.formation_oy
+	var ox_before: float = s.formation_ox
+	var dir_before: int = s.formation_dir
+	s._step_formation()
+	assert_eq(s.formation_dir, -dir_before, "direction reversed")
+	assert_almost_eq(s.formation_oy, oy_before + c.step_dy, 1e-6)
+	# ox stays put on bounce frame.
+	assert_almost_eq(s.formation_ox, ox_before, 1e-6)
+
+
+# --- Player bullet vs enemies ---
+
+func test_fire_then_hit_increments_score() -> void:
+	var c: Cfg = _cfg()
+	c.player_bullet_speed = 5000.0  # ridiculously fast → next sub-step the
+	# bullet should fly past the formation if we don't hit. But we *do*
+	# want a hit, so position it precisely.
+	# Set tunneling cap loosely: feature ≥ step_dist. With 16 ms sub-step,
+	# 5000 * 0.016 = 80; so cell_h must be ≥ 80. Bump.
+	c.cell_h = 100.0
+	c.enemy_hy = 50.0
+	c.player_bullet_h = 100.0
+	c.player_h = 100.0
+	c.bunker_cell_h = 100.0
+	var s = State.create(0, c, _lvl())
+	# Place bullet just below row 4 of column 5 (center of formation).
+	s.player_bullet_alive = true
+	var col: int = 5
+	var row: int = 4
+	s.player_bullet_x = s.formation_ox + col * c.cell_w + c.cell_w * 0.5
+	s.player_bullet_y = s.formation_oy + row * c.cell_h + c.cell_h * 0.5
+	var hit: bool = s._player_bullet_vs_enemies()
+	assert_true(hit)
+	assert_eq(s.live_mask[row * c.cols + col], 0)
+	assert_false(s.player_bullet_alive)
+	# Score should now be > 0 (row 4 → kind index from level row_kinds[4]=0
+	# → row_values[0] = 30 by our default).
+	assert_gt(s.score, 0)
+
+
+# --- Enemy bullet cap ---
+
+func test_enemy_bullet_cap_initial_wave() -> void:
+	var s = State.create(0, _cfg(), _lvl())
+	# Cap at wave 1 = enemy_bullets_max_init.
+	assert_eq(s._max_enemy_bullets(), s.config.enemy_bullets_max_init)
+
+
+func test_enemy_bullet_cap_grows_with_wave() -> void:
+	var s = State.create(0, _cfg(), _lvl())
+	s.wave = 3
+	# +1 per wave step (default wave_step=1, per_wave=1) → init + 2.
+	assert_eq(s._max_enemy_bullets(),
+			s.config.enemy_bullets_max_init + 2 * s.config.enemy_bullets_per_wave)
+
+
+func test_spawn_enemy_bullet_uses_bottom_of_column() -> void:
+	var s = State.create(0, _cfg(), _lvl())
+	# Force the bullet RNG into a state where the seeded column has a known
+	# bottom row. Easier: kill all of row 4 entirely, so any column's
+	# bottom is row 3.
+	for c in range(s.config.cols):
+		s.live_mask[4 * s.config.cols + c] = 0
+	var ok: bool = s._spawn_enemy_bullet()
+	assert_true(ok)
+	# The new bullet's y should equal: formation_oy + 3*cell_h + cell_h/2 +
+	# enemy_hy + bullet_h/2 + epsilon.
+	var bullet: Dictionary = s.enemy_bullets[s.enemy_bullets.size() - 1]
+	var expected_min_y: float = s.formation_oy + 3.0 * s.config.cell_h + s.config.cell_h * 0.5 + s.config.enemy_hy
+	assert_gt(float(bullet["y"]), expected_min_y - 0.001)
+
+
+# --- Loss conditions ---
+
+func test_loss_by_lives_zero() -> void:
+	var s = State.create(0, _cfg(), _lvl())
+	s.lives = 0
+	assert_true(s.is_game_over())
+
+
+func test_loss_by_formation_reaching_player() -> void:
+	var s = State.create(0, _cfg(), _lvl())
+	# Drop the formation so its bottom enemies sit on top of the player.
+	s.formation_oy = s.config.player_y - s.config.player_h * 0.5 \
+			- s.config.cell_h * (s.config.rows - 1) - s.config.cell_h * 0.5 \
+			- s.config.enemy_hy + 10.0
+	# This places bottom row's center near player; bounds_y bottom should
+	# exceed player_top.
+	assert_true(s.is_game_over())
+
+
+# --- Wave progression ---
+
+func test_wave_progression_clears_formation_and_increases_wave() -> void:
+	var s = State.create(0, _cfg(), _lvl())
+	# Kill everyone.
+	for i in range(s.live_mask.size()):
+		s.live_mask[i] = 0
+	# Set up a UFO so we can verify it's cleared.
+	s.ufo_alive = true
+	s.ufo_x = 50.0
+	s._advance_wave()
+	assert_eq(s.wave, 2)
+	# Formation refilled.
+	var live: int = 0
+	for i in range(s.live_mask.size()):
+		live += s.live_mask[i]
+	assert_eq(live, s.config.rows * s.config.cols)
+	# UFO removed.
+	assert_false(s.ufo_alive)
+	# Speed faster: step_ms_init * factor < step_ms_init.
+	assert_lt(s.formation_step_ms, s.config.step_ms_init)
+
+
+# --- UFO ---
+
+func test_ufo_spawn_off_left_or_right_edge() -> void:
+	var s = State.create(0, _cfg(), _lvl())
+	# Force a spawn by setting last_ufo_spawn_ms way back.
+	s.last_tick_ms = 100000
+	s.last_ufo_spawn_ms = 0
+	# step_ufo with a bigger dt to trigger the should_spawn path.
+	var changed: bool = s._step_ufo(0.016, 16)
+	# Either spawned or didn't (depends on rng); if spawned, x must be at
+	# either edge.
+	if s.ufo_alive:
+		assert_true(changed)
+		var hw: float = s.config.ufo_w * 0.5
+		assert_true(s.ufo_x <= -hw + 0.001 or s.ufo_x >= s.config.world_w + hw - 0.001)
+
+
+func test_ufo_offscreen_removes_without_score() -> void:
+	var s = State.create(0, _cfg(), _lvl())
+	s.ufo_alive = true
+	s.ufo_dir = 1
+	s.ufo_x = s.config.world_w + s.config.ufo_w  # already past right edge
+	var score_before: int = s.score
+	s._step_ufo(0.001, 1)
+	assert_false(s.ufo_alive)
+	assert_eq(s.score, score_before)
+
+
+func test_ufo_hit_by_player_bullet_awards_table_score() -> void:
+	var c: Cfg = _cfg()
+	# Loosen tunneling cap.
+	c.player_bullet_speed = 100.0
+	var s = State.create(0, c, _lvl())
+	s.ufo_alive = true
+	s.ufo_x = 100.0
+	# Place bullet on top of UFO.
+	s.player_bullet_alive = true
+	s.player_bullet_x = s.ufo_x
+	s.player_bullet_y = c.ufo_y
+	var hit: bool = s._player_bullet_vs_ufo()
+	assert_true(hit)
+	assert_false(s.ufo_alive)
+	assert_false(s.player_bullet_alive)
+	# Score is one of the deterministic table.
+	var v: int = s.score
+	assert_true(v == 50 or v == 100 or v == 150 or v == 300, "got %d" % v)

--- a/godot/tests/unit/invaders/test_state_collisions.gd.uid
+++ b/godot/tests/unit/invaders/test_state_collisions.gd.uid
@@ -1,0 +1,1 @@
+uid://l47gdqjdy4qo

--- a/godot/tests/unit/invaders/test_state_lifecycle.gd
+++ b/godot/tests/unit/invaders/test_state_lifecycle.gd
@@ -1,0 +1,172 @@
+extends GutTest
+## InvadersGameState — lifecycle, public API, snapshot round-trip,
+## tunneling cap.
+
+const State := preload("res://scripts/invaders/core/invaders_state.gd")
+const Cfg := preload("res://scripts/invaders/core/invaders_config.gd")
+const Lvl := preload("res://scripts/invaders/core/invaders_level.gd")
+
+
+func _cfg() -> Cfg:
+	return Cfg.new()
+
+
+func _lvl() -> Lvl:
+	return Lvl.new()
+
+
+func test_create_default_returns_state() -> void:
+	var s = State.create(123, _cfg(), _lvl())
+	assert_not_null(s)
+	assert_eq(s.lives, 3)
+	assert_eq(s.wave, 1)
+	assert_eq(s.score, 0)
+	assert_eq(s.player_alive, true)
+	# Full population.
+	assert_eq(s.live_mask.size(), 5 * 11)
+	var alive: int = 0
+	for i in range(s.live_mask.size()):
+		alive += s.live_mask[i]
+	assert_eq(alive, 55)
+
+
+func test_set_player_intent_clamped() -> void:
+	var s = State.create(0, _cfg(), _lvl())
+	s.set_player_intent(99999.0)
+	assert_almost_eq(s.player_intent_vx, 90.0, 1e-6)
+	s.set_player_intent(-99999.0)
+	assert_almost_eq(s.player_intent_vx, -90.0, 1e-6)
+	s.set_player_intent(50.0)
+	assert_almost_eq(s.player_intent_vx, 50.0, 1e-6)
+
+
+func test_fire_single_bullet_invariant() -> void:
+	var s = State.create(0, _cfg(), _lvl())
+	# First fire succeeds.
+	assert_true(s.fire())
+	assert_true(s.player_bullet_alive)
+	# Second fire while alive → false.
+	assert_false(s.fire())
+	# Once bullet flies off-screen (manually clear), fire allowed again.
+	s.player_bullet_alive = false
+	assert_true(s.fire())
+
+
+func test_fire_when_dead_returns_false() -> void:
+	var s = State.create(0, _cfg(), _lvl())
+	s.player_alive = false
+	assert_false(s.fire())
+
+
+func test_set_last_tick_resets_clock_without_simulating() -> void:
+	var s = State.create(0, _cfg(), _lvl())
+	# Run a tick to initialize the clock.
+	s.tick(0)
+	# Now jump 5 seconds via set_last_tick → no simulation.
+	var live_before: int = 0
+	for i in range(s.live_mask.size()):
+		live_before += s.live_mask[i]
+	var ox_before: float = s.formation_ox
+	s.set_last_tick(5000)
+	# Mask + origin unchanged.
+	var live_after: int = 0
+	for i in range(s.live_mask.size()):
+		live_after += s.live_mask[i]
+	assert_eq(live_after, live_before)
+	assert_almost_eq(s.formation_ox, ox_before, 1e-6)
+
+
+func test_tick_returns_bool() -> void:
+	var s = State.create(0, _cfg(), _lvl())
+	# First tick initializes clock; with no time elapsed across the very
+	# first call there shouldn't be motion.
+	var changed: bool = s.tick(0)
+	# Subsequent tick after some time should change state (player intent
+	# is zero, but formation cadence may step).
+	assert_typeof(changed, TYPE_BOOL)
+	# Run a longer tick — bullets fired, motion applied, etc.
+	s.set_player_intent(50.0)
+	var c2: bool = s.tick(200)
+	assert_true(c2)
+
+
+func test_is_game_over_initial() -> void:
+	var s = State.create(0, _cfg(), _lvl())
+	assert_false(s.is_game_over())
+
+
+func test_current_wave_starts_at_1() -> void:
+	var s = State.create(0, _cfg(), _lvl())
+	assert_eq(s.current_wave(), 1)
+
+
+func test_snapshot_has_required_keys() -> void:
+	var s = State.create(42, _cfg(), _lvl())
+	var snap: Dictionary = s.snapshot()
+	assert_eq(snap["version"], 1)
+	for key in ["wave", "score", "lives", "formation", "enemies",
+			"enemy_kinds", "player", "player_bullet", "enemy_bullets",
+			"bunkers", "ufo", "last_ufo_spawn_ms", "divers",
+			"rng_master", "rng_bullet", "rng_ufo", "rng_dive"]:
+		assert_true(snap.has(key), "snapshot missing key: %s" % key)
+	# Reserved fields present and empty/zero-shaped.
+	assert_eq(snap["divers"], [])
+	assert_eq(snap["ufo"], null)
+	assert_eq(snap["rng_master"], 42)
+
+
+func test_snapshot_round_trip_preserves_state() -> void:
+	var s = State.create(7, _cfg(), _lvl())
+	# Drive some changes.
+	s.set_player_intent(50.0)
+	s.tick(0)
+	s.tick(500)
+	s.fire()
+	var snap: Dictionary = s.snapshot()
+	var s2 = State.from_snapshot(snap, _cfg(), _lvl())
+	var snap2: Dictionary = s2.snapshot()
+	# Compare the deterministic fields.
+	assert_eq(snap2["version"], snap["version"])
+	assert_eq(snap2["wave"], snap["wave"])
+	assert_eq(snap2["score"], snap["score"])
+	assert_eq(snap2["lives"], snap["lives"])
+	assert_almost_eq(snap2["formation"]["ox"], snap["formation"]["ox"], 1e-6)
+	assert_eq(snap2["enemies"], snap["enemies"])
+	assert_eq(snap2["bunkers"].size(), snap["bunkers"].size())
+	for i in range(snap["bunkers"].size()):
+		assert_eq(snap2["bunkers"][i], snap["bunkers"][i], "bunker %d differs" % i)
+	assert_eq(snap2["player_bullet"]["alive"], snap["player_bullet"]["alive"])
+
+
+func test_reserved_divers_and_rng_dive_present() -> void:
+	var s = State.create(0, _cfg(), _lvl())
+	var snap: Dictionary = s.snapshot()
+	# v1 always emits these so that the dive PR can populate without
+	# bumping `version`.
+	assert_eq(snap["divers"], [])
+	assert_true(snap.has("rng_dive"))
+
+
+func test_tunneling_cap_violation_returns_null() -> void:
+	# Crank player bullet speed so that one sub-step (16 ms) exceeds the
+	# smallest collidable feature, forcing the cap to refuse.
+	var c: Cfg = _cfg()
+	# At 16 ms sub-step, a speed of 1500 px/s travels 24 px > player_h (8).
+	c.player_bullet_speed = 1500.0
+	var s = State.create(0, c, _lvl())
+	assert_null(s)
+	# create() should have emitted a push_error explaining the violation.
+	assert_push_error("tunneling cap violated")
+
+
+func test_sub_rng_independence_dive_does_not_perturb_bullet() -> void:
+	# Two states with same master seed; consume from `_dive_rng` on one of
+	# them. The bullet stream must be unaffected (acceptance #14).
+	var s1 = State.create(99, _cfg(), _lvl())
+	var s2 = State.create(99, _cfg(), _lvl())
+	# Drain a few values from s2's dive rng (simulating dive PR's consumer).
+	for _i in range(50):
+		s2._dive_rng.randi()
+	# Both must emit identical bullet RNG draws.
+	for _i in range(20):
+		assert_eq(s1._bullet_rng.randi(), s2._bullet_rng.randi())

--- a/godot/tests/unit/invaders/test_state_lifecycle.gd.uid
+++ b/godot/tests/unit/invaders/test_state_lifecycle.gd.uid
@@ -1,0 +1,1 @@
+uid://bitguje4tdc7r

--- a/godot/tests/unit/invaders/test_ufo.gd
+++ b/godot/tests/unit/invaders/test_ufo.gd
@@ -1,0 +1,67 @@
+extends GutTest
+## ufo.gd — score table, direction, spawn timing.
+
+const Ufo := preload("res://scripts/invaders/core/ufo.gd")
+
+
+func _rng(seed_val: int) -> RandomNumberGenerator:
+	var r := RandomNumberGenerator.new()
+	r.seed = seed_val
+	return r
+
+
+func test_score_table_values() -> void:
+	# Static table — exact values are part of the contract.
+	assert_eq(Ufo.SCORE_TABLE[0], 50)
+	assert_eq(Ufo.SCORE_TABLE[1], 100)
+	assert_eq(Ufo.SCORE_TABLE[2], 150)
+	assert_eq(Ufo.SCORE_TABLE[3], 300)
+	assert_eq(Ufo.SCORE_TABLE.size(), 4)
+
+
+func test_pick_score_in_table() -> void:
+	# Whatever rng produces, score must be one of the four.
+	var r := _rng(12345)
+	for _i in range(50):
+		var s: int = Ufo.pick_score(r)
+		assert_true(s == 50 or s == 100 or s == 150 or s == 300, "got %d" % s)
+
+
+func test_pick_score_deterministic_from_seed() -> void:
+	# Same seed → same sequence.
+	var r1 := _rng(42); var r2 := _rng(42)
+	var seq1: Array = []
+	var seq2: Array = []
+	for _i in range(10):
+		seq1.append(Ufo.pick_score(r1))
+		seq2.append(Ufo.pick_score(r2))
+	assert_eq(seq1, seq2)
+
+
+func test_pick_direction_returns_valid() -> void:
+	var r := _rng(7)
+	for _i in range(30):
+		var d: int = Ufo.pick_direction(r)
+		assert_true(d == 1 or d == -1)
+
+
+func test_should_spawn_false_before_interval() -> void:
+	var r := _rng(1)
+	# now=0, last=0, interval=1000, jitter=0 → 0 - 0 < 1000 + 0 → false.
+	assert_false(Ufo.should_spawn(r, 0, 0, 1000, 0))
+
+
+func test_should_spawn_true_after_interval_no_jitter() -> void:
+	var r := _rng(1)
+	# now=2000, last=0, interval=1000, jitter=0 → 2000 >= 1000 → true.
+	assert_true(Ufo.should_spawn(r, 2000, 0, 1000, 0))
+
+
+func test_should_spawn_with_jitter_bounded() -> void:
+	# With interval=1000 jitter=200, threshold ∈ [900, 1100]. At now=900,
+	# regardless of seed, should_spawn must return true OR false (not crash).
+	var r := _rng(1)
+	for _i in range(20):
+		var _b: bool = Ufo.should_spawn(r, 1000, 0, 1000, 200)
+		# Just exercise — no assertion needed beyond "doesn't crash".
+		assert_not_null(r)

--- a/godot/tests/unit/invaders/test_ufo.gd.uid
+++ b/godot/tests/unit/invaders/test_ufo.gd.uid
@@ -1,0 +1,1 @@
+uid://orp6cqehrt7w


### PR DESCRIPTION
Closes #27

## How tested
- GUT tests pass locally in worktree (336/336 across the whole repo).
- New invaders unit tests cover Dev plan §Tests:
  - Formation: bounds, live-count, speed-curve monotonicity, edge bounce (reverse + drop, no horizontal step on bounce frame), firing-column walk, bottom-of-column lookup.
  - Bunker grid: stamp clip, snapshot round-trip, AABB hit early-rejects out-of-grid AABBs.
  - Bunker erosion: PLAYER_UP and ENEMY_DOWN stamp shapes are pinned constants (test oracle).
  - UFO: deterministic score table, deterministic pick under fixed seed, direction picker.
  - State lifecycle: single-player-bullet invariant, fire-when-dead, set_last_tick semantics, snapshot v1 schema (incl. reserved `divers` and `rng_dive`), tunneling-cap violation returns null with `assert_push_error`.
  - Sub-RNG independence: draining `_dive_rng` on one state does NOT perturb the bullet stream of another with the same seed (acceptance #14).
  - Collisions: player-bullet vs enemies awards configured row-value, enemy-bullet cap grows linearly with wave, spawn picks bottom-most live enemy of column, loss-by-lives, loss-by-formation-reaching-player, wave progression refills + speeds up + clears active UFO, UFO offscreen removed without score.

## Implementation notes
- Pure GDScript core: no Node, no signals (per architecture rule). `tick(now_ms) -> bool` returns whether visible state changed; scene-side observes via snapshot diff.
- Sub-RNG split (`_bullet_rng`, `_ufo_rng`, `_dive_rng`) at create() with disjoint XOR tags. Adding consumers in the dive PR cannot perturb v1 fixtures.
- Snapshot v1 reserves `divers: []` and `rng_dive` so the dive follow-up can populate them without bumping `version`.
- Bunker erosion stamps are inline ASCII bit-pattern constants in `bunker_erosion.gd` — they are the test oracle (no derivation, no risk of two implementers diverging).
- Tunneling cap (acceptance #12) compares max bullet step (per sub-step) against the smallest *broad-phase* collidable feature: `min(2*enemy_hy, player_h)`. Bunker cells (2 px) are deliberately excluded since bunker hits use a cell-range scan, not point sampling. Violation calls `push_error` and returns `null`.
- `aabb.gd` is local to invaders/core (no cross-game dependency on breakout's helpers).

## Estimated effective diff
1121 lines (total 1856, excluded 735).

⚠️ Exceeds 400 effective lines. Issue must carry the `large-pr-ok` label for auto-merge; otherwise human review will be required.