### PR TITLE
feat(g2048): SFX, haptics, undo, persistent best

### DIFF
--- a/docs/input-mapping.md
+++ b/docs/input-mapping.md
@@ -15,9 +15,12 @@ The `InputManager` autoload (added in task #2) exposes **semantic actions** so g
 | `rotate_cw`  | ↑ / X          | B                      | Circle             | Right-half tap |
 | `rotate_ccw` | Z              | X                      | Square             | Left-half tap  |
 | `hold`       | C / Shift      | Y / LB                 | Triangle / L1      | Two-finger tap |
+| `undo`       | Z              | Y                      | Triangle           | (HUD button)   |
 | `pause`      | Esc / P        | Start / Menu           | Options            | Pause button   |
 
 `move_up` and `move_down` are semantic 4-direction equivalents of `move_left`/`move_right` for grid-based games (Snake, 2048). They intentionally share keys with `rotate_cw` (↑) and `soft_drop` (↓); per-game scenes consume only the actions they care about, so the overlap is harmless.
+
+`undo` shares its keyboard default (Z) with `rotate_ccw` and its gamepad default (Y / Triangle) with `hold`. Same rationale: 2048 listens for `undo`, Tetris listens for `rotate_ccw` / `hold` — actions don't compete unless a single scene subscribes to both, which none do.
 
 ## DAS / ARR (auto repeat)
 

--- a/godot/scenes/g2048/g2048.gd
+++ b/godot/scenes/g2048/g2048.gd
@@ -22,6 +22,20 @@ const Game2048State := preload("res://scripts/g2048/core/g2048_state.gd")
 const Planner := preload("res://scripts/g2048/core/g2048_planner.gd")
 const TileScript := preload("res://scenes/g2048/view/tile.gd")
 const Palette := preload("res://scripts/g2048/tile_palette.gd")
+const SfxTones := preload("res://scripts/core/audio/sfx_tones.gd")
+const SfxVolume := preload("res://scripts/core/audio/sfx_volume.gd")
+const Haptics := preload("res://scripts/core/input/haptics.gd")
+
+const BEST_KEY: StringName = &"g2048.best"
+
+# Haptic tier table per Dev plan: (value_threshold, intensity, duration_ms).
+# First row whose merged value is < threshold wins; last row is the cap.
+const _HAPTIC_TIERS: Array = [
+	[16,    0.2,  60],
+	[128,   0.4, 100],
+	[1024,  0.6, 140],
+	[INF,   0.9, 200],
+]
 
 # GameHost contract.
 signal exit_requested()
@@ -72,21 +86,85 @@ var _win_shown: bool = false
 var _touch_index: int = -1
 var _touch_start: Vector2 = Vector2.ZERO
 
+# Polish state (issue #21): undo + sfx + best.
+# `_last_snapshot` holds the pre-commit state.snapshot() captured immediately
+# before each successful state.commit(). Empty Dictionary == no undo available.
+var _last_snapshot: Dictionary = {}
+var _best_score: int = 0
+# Once the player has won (reached the target tile), don't replay the jingle
+# every move — cap to one play per session.
+var _2048_sfx_played: bool = false
+
+# SFX players. Created in _ready, streams cached.
+var _sfx_slide: AudioStreamPlayer
+var _sfx_merge: AudioStreamPlayer
+var _sfx_2048: AudioStreamPlayer
+var _sfx_over: AudioStreamPlayer
+
 
 func _ready() -> void:
 	pause_overlay.visible = false
 	game_over_overlay.visible = false
 	win_overlay.visible = false
+	_setup_sfx()
 	InputManager.action_pressed.connect(_on_action_pressed)
 	game_over_overlay.restart_requested.connect(_on_restart_pressed)
 	game_over_overlay.menu_requested.connect(_on_menu_pressed)
 	pause_overlay.menu_requested.connect(_on_menu_pressed)
 	win_overlay.continue_requested.connect(_on_continue_pressed)
 	win_overlay.menu_requested.connect(_on_menu_pressed)
+	hud.undo_pressed.connect(_on_undo_invoked)
+	if _has_settings():
+		Settings.changed.connect(_on_settings_changed)
+		_apply_sfx_volume()
 	# Standalone launch (project main scene == us, or scene loaded directly
 	# in a test). Tests override state via start() afterwards.
 	if get_tree().current_scene == self:
 		start(0)
+
+
+func _setup_sfx() -> void:
+	_sfx_slide = AudioStreamPlayer.new()
+	_sfx_slide.stream = SfxTones.tone(220.0, 0.06, 0.4)
+	add_child(_sfx_slide)
+	_sfx_merge = AudioStreamPlayer.new()
+	# Merge stream is replaced per-event with a freshly-tuned tone (tier-aware).
+	add_child(_sfx_merge)
+	_sfx_2048 = AudioStreamPlayer.new()
+	_sfx_2048.stream = SfxTones.tone_sequence([
+		Vector2(523.0, 0.10),
+		Vector2(659.0, 0.10),
+		Vector2(784.0, 0.16),
+	])
+	add_child(_sfx_2048)
+	_sfx_over = AudioStreamPlayer.new()
+	_sfx_over.stream = SfxTones.tone_sequence([
+		Vector2(330.0, 0.12),
+		Vector2(247.0, 0.18),
+		Vector2(165.0, 0.30),
+	])
+	add_child(_sfx_over)
+
+
+func _has_settings() -> bool:
+	return get_tree().root.has_node("Settings")
+
+
+func _apply_sfx_volume() -> void:
+	if not _has_settings():
+		return
+	var master: float = float(Settings.get_value(&"audio.master", 1.0))
+	var sfx: float = float(Settings.get_value(&"audio.sfx", 1.0))
+	var v: float = SfxVolume.linear_volume(master, sfx)
+	for p in [_sfx_slide, _sfx_merge, _sfx_2048, _sfx_over]:
+		if p != null:
+			SfxVolume.set_player_volume(p, v)
+
+
+func _on_settings_changed(key: StringName) -> void:
+	var s: String = String(key)
+	if s == "audio.master" or s == "audio.sfx":
+		_apply_sfx_volume()
 
 
 # --- GameHost contract ---
@@ -100,7 +178,9 @@ func start(seed_value: int = 0) -> void:
 	_input_gate_open = true
 	_buffered_dir = -1
 	_win_shown = false
+	_2048_sfx_played = false
 	_last_reported_score = -1
+	_last_snapshot = {}
 	pause_overlay.visible = false
 	game_over_overlay.visible = false
 	win_overlay.visible = false
@@ -115,6 +195,10 @@ func start(seed_value: int = 0) -> void:
 	grid_view.configure(config.size, CELL_PX, GAP_PX)
 	# Sync tile mirror to current grid (the two starter tiles).
 	_sync_tiles_from_state(true)
+	# Load best from Settings (0 if absent), push to HUD.
+	_best_score = _load_best()
+	hud.update_best(_best_score)
+	hud.set_undo_enabled(false)
 	_emit_score_if_changed()
 
 
@@ -171,6 +255,9 @@ func _any_tile_animating() -> bool:
 func _on_action_pressed(action: StringName) -> void:
 	if action == &"pause":
 		_toggle_pause()
+		return
+	if action == &"undo":
+		_on_undo_invoked()
 		return
 	if pause_overlay.visible:
 		return
@@ -234,11 +321,14 @@ func _apply_direction(dir: int) -> void:
 	if p == null or p.is_empty():
 		# No-op move: gate stays open, no animation, no spawn.
 		return
+	# Capture pre-commit snapshot for undo BEFORE state mutates.
+	_last_snapshot = state.snapshot()
 	# Close the gate and seed animations BEFORE commit, so we know which
 	# pre-state cells the surviving / dying tiles came from.
 	_input_gate_open = false
 	# Snapshot the pre-commit grid so we can rebuild missing tiles after
 	# replays / state restoration.
+	var max_merge_value: int = 0
 	for m in p.moves:
 		var tm: Planner.TileMove = m
 		var tile: TileScript = _ensure_tile_for(tm.id)
@@ -253,11 +343,25 @@ func _apply_direction(dir: int) -> void:
 		tile.set_meta(&"post_value", tm.new_value)
 		tile.set_meta(&"to_cell", tm.to_cell)
 		tile.set_meta(&"is_merge_survivor", tm.merged_into == -1 and _is_merge_survivor(p, tm))
+		# Track the largest merge for tier-aware sfx + haptic.
+		if tm.merged_into == -1 and _is_merge_survivor(p, tm):
+			if tm.new_value > max_merge_value:
+				max_merge_value = tm.new_value
 	# Commit the move: state mutates, score updates, new tile spawns.
 	state.commit(p)
+	# SFX: every non-empty plan plays a slide blip; merges escalate with tier.
+	_play_slide_sfx()
+	if max_merge_value > 0:
+		_play_merge_sfx(max_merge_value)
+		var tier: Dictionary = Haptics.tier_for(max_merge_value, _HAPTIC_TIERS)
+		Haptics.pulse(float(tier["intensity"]), int(tier["duration_ms"]))
 	# Sync new spawn (id present in state but not in our mirror) with fade-in.
 	_sync_tiles_from_state(false)
 	_emit_score_if_changed()
+	# Update best on every score change.
+	_update_best()
+	# A successful, non-empty commit refills the undo charge.
+	hud.set_undo_enabled(not _last_snapshot.is_empty())
 
 
 # A "merge survivor" is a TileMove where the planner recorded another
@@ -297,16 +401,25 @@ func _finish_animation_round() -> void:
 	if state != null and state.is_won() and not _win_shown:
 		_win_shown = true
 		_phase = Phase.WON_CONTINUING
+		if not _2048_sfx_played:
+			_2048_sfx_played = true
+			if _sfx_2048 != null:
+				_sfx_2048.play()
 		win_overlay.show_with(int(state.snapshot().get("score", 0)))
 		# Don't reopen the gate while the win overlay is visible; it gets
 		# reopened in _on_continue_pressed.
+		hud.set_undo_enabled(false)
 		return
 	# Game-over check (acceptance #6).
 	if state != null and state.is_lost():
 		_phase = Phase.GAME_OVER
+		if _sfx_over != null:
+			_sfx_over.play()
 		game_over_overlay.show_with(int(state.snapshot().get("score", 0)))
+		hud.set_undo_enabled(false)
 		return
 	_input_gate_open = true
+	hud.set_undo_enabled(_can_undo())
 
 
 # --- Tile pool ---
@@ -401,7 +514,81 @@ func _on_continue_pressed() -> void:
 	# moves don't re-show this overlay.
 	_phase = Phase.WON_CONTINUING
 	_input_gate_open = true
+	hud.set_undo_enabled(_can_undo())
 
 
 func _on_menu_pressed() -> void:
 	exit_requested.emit()
+
+
+# --- Polish helpers (issue #21) ---
+
+
+func _can_undo() -> bool:
+	if _last_snapshot.is_empty():
+		return false
+	if not _input_gate_open:
+		return false
+	if pause_overlay.visible or win_overlay.visible or game_over_overlay.visible:
+		return false
+	return true
+
+
+## Restore _last_snapshot to state, rebuild tile mirror, clear undo charge.
+## Bound to both `undo` action and the HUD button.
+func _on_undo_invoked() -> void:
+	if not _can_undo():
+		return
+	state = Game2048State.from_snapshot(_last_snapshot)
+	_last_snapshot = {}
+	# Wipe tile mirror — `_sync_tiles_from_state(true)` snaps every restored
+	# tile to its restored cell with no animation, which is exactly what we
+	# want after an undo (no slide/pop fanfare).
+	for id in _tile_nodes.keys():
+		var t: Node2D = _tile_nodes[id]
+		t.visible = false
+		_tile_pool.append(t)
+	_tile_nodes.clear()
+	_sync_tiles_from_state(true)
+	_emit_score_if_changed()
+	hud.set_undo_enabled(false)
+
+
+func _play_slide_sfx() -> void:
+	if _sfx_slide == null:
+		return
+	_sfx_slide.play()
+
+
+func _play_merge_sfx(merged_value: int) -> void:
+	if _sfx_merge == null:
+		return
+	# Merged values are powers of 2 starting at 4. Map exponent → frequency:
+	# higher tiles ring at lower pitch (heavier feel).
+	var exp: float = clamp(log(float(merged_value)) / log(2.0), 2.0, 14.0)
+	var freq: float = 880.0 - 50.0 * (exp - 2.0)
+	_sfx_merge.stream = SfxTones.tone_chord([freq, freq * 1.5], 0.10, 0.5)
+	_sfx_merge.play()
+
+
+func _load_best() -> int:
+	if not _has_settings():
+		return 0
+	return int(Settings.get_value(BEST_KEY, 0))
+
+
+func _save_best(value: int) -> void:
+	if not _has_settings():
+		return
+	Settings.set_value(BEST_KEY, value)
+
+
+## Push the current score to `g2048.best` if higher, and refresh the HUD label.
+func _update_best() -> void:
+	if state == null:
+		return
+	var s: int = int(state.snapshot().get("score", 0))
+	if s > _best_score:
+		_best_score = s
+		_save_best(_best_score)
+		hud.update_best(_best_score)

--- a/godot/scenes/g2048/view/hud.gd
+++ b/godot/scenes/g2048/view/hud.gd
@@ -1,8 +1,11 @@
 extends VBoxContainer
-## 2048 HUD — current score and best (best is placeholder until polish task).
+## 2048 HUD — score, best, undo button.
+
+signal undo_pressed()
 
 var _score_label: Label
 var _best_label: Label
+var _undo_button: Button
 
 
 func _ready() -> void:
@@ -11,14 +14,33 @@ func _ready() -> void:
 	_score_label.add_theme_font_size_override("font_size", 24)
 	add_child(_score_label)
 	_best_label = Label.new()
-	_best_label.text = "Best: --"
+	_best_label.text = "Best: 0"
 	_best_label.add_theme_font_size_override("font_size", 18)
 	add_child(_best_label)
+	_undo_button = Button.new()
+	_undo_button.text = "Undo (Z)"
+	_undo_button.disabled = true
+	_undo_button.pressed.connect(_on_undo_button_pressed)
+	add_child(_undo_button)
 
 
 func update_from_snapshot(snap: Dictionary) -> void:
 	if _score_label == null:
 		return
 	_score_label.text = "Score: %d" % int(snap.get("score", 0))
-	# Best is wired in the polish task (#21). Show a static placeholder for now.
-	_best_label.text = "Best: --"
+
+
+func update_best(value: int) -> void:
+	if _best_label == null:
+		return
+	_best_label.text = "Best: %d" % value
+
+
+func set_undo_enabled(enabled: bool) -> void:
+	if _undo_button == null:
+		return
+	_undo_button.disabled = not enabled
+
+
+func _on_undo_button_pressed() -> void:
+	undo_pressed.emit()

--- a/godot/scripts/core/audio/sfx_tones.gd
+++ b/godot/scripts/core/audio/sfx_tones.gd
@@ -1,0 +1,95 @@
+extends RefCounted
+## Procedural SFX tone synthesis.
+##
+## No binary OGG assets — generates short PCM blips at runtime. Keeps the
+## CI workflow free of LFS / asset bookkeeping and the headless test suite
+## free of audio-decoder dependencies.
+##
+## Usage: `var stream := SfxTones.tone(440.0, 0.12)` returns an
+## AudioStreamWAV ready to feed an `AudioStreamPlayer.stream`. For chords
+## or two-note jingles, sum samples via `tone_chord` / `tone_sequence`.
+
+const SAMPLE_RATE: int = 22050
+
+
+## Single sine tone with linear attack/decay envelope. `freq_hz` 0 → silence.
+static func tone(freq_hz: float, duration_s: float, volume: float = 0.6) -> AudioStreamWAV:
+	var n: int = int(duration_s * SAMPLE_RATE)
+	var samples: PackedByteArray = PackedByteArray()
+	samples.resize(n * 2)
+	var attack: int = int(0.01 * SAMPLE_RATE)
+	var decay: int = int(0.04 * SAMPLE_RATE)
+	for i in n:
+		var env: float = 1.0
+		if i < attack:
+			env = float(i) / float(max(1, attack))
+		elif i > n - decay:
+			env = float(n - i) / float(max(1, decay))
+		var s: float = sin(TAU * freq_hz * float(i) / float(SAMPLE_RATE))
+		var v: int = int(clamp(s * env * volume, -1.0, 1.0) * 32767.0)
+		samples[i * 2] = v & 0xFF
+		samples[i * 2 + 1] = (v >> 8) & 0xFF
+	return _wav_from_pcm(samples)
+
+
+## Sum two sines for a quick "merge" feel. Frequencies in Hz.
+static func tone_chord(freqs: Array, duration_s: float, volume: float = 0.5) -> AudioStreamWAV:
+	var n: int = int(duration_s * SAMPLE_RATE)
+	var samples: PackedByteArray = PackedByteArray()
+	samples.resize(n * 2)
+	var attack: int = int(0.01 * SAMPLE_RATE)
+	var decay: int = int(0.05 * SAMPLE_RATE)
+	var k: int = max(1, freqs.size())
+	for i in n:
+		var env: float = 1.0
+		if i < attack:
+			env = float(i) / float(max(1, attack))
+		elif i > n - decay:
+			env = float(n - i) / float(max(1, decay))
+		var sum: float = 0.0
+		for f in freqs:
+			sum += sin(TAU * float(f) * float(i) / float(SAMPLE_RATE))
+		var s: float = sum / float(k)
+		var v: int = int(clamp(s * env * volume, -1.0, 1.0) * 32767.0)
+		samples[i * 2] = v & 0xFF
+		samples[i * 2 + 1] = (v >> 8) & 0xFF
+	return _wav_from_pcm(samples)
+
+
+## Concatenate a list of (freq_hz, duration_s) pairs into one stream.
+## Use Vector2(freq, dur). freq=0 = silence segment.
+static func tone_sequence(steps: Array, volume: float = 0.55) -> AudioStreamWAV:
+	var total_n: int = 0
+	for step in steps:
+		total_n += int(step.y * SAMPLE_RATE)
+	var samples: PackedByteArray = PackedByteArray()
+	samples.resize(total_n * 2)
+	var idx: int = 0
+	for step in steps:
+		var freq: float = step.x
+		var seg_n: int = int(step.y * SAMPLE_RATE)
+		var attack: int = int(0.005 * SAMPLE_RATE)
+		var decay: int = int(0.01 * SAMPLE_RATE)
+		for i in seg_n:
+			var env: float = 1.0
+			if i < attack:
+				env = float(i) / float(max(1, attack))
+			elif i > seg_n - decay:
+				env = float(seg_n - i) / float(max(1, decay))
+			var s: float = 0.0
+			if freq > 0.0:
+				s = sin(TAU * freq * float(i) / float(SAMPLE_RATE))
+			var v: int = int(clamp(s * env * volume, -1.0, 1.0) * 32767.0)
+			samples[idx * 2] = v & 0xFF
+			samples[idx * 2 + 1] = (v >> 8) & 0xFF
+			idx += 1
+	return _wav_from_pcm(samples)
+
+
+static func _wav_from_pcm(samples: PackedByteArray) -> AudioStreamWAV:
+	var w: AudioStreamWAV = AudioStreamWAV.new()
+	w.format = AudioStreamWAV.FORMAT_16_BITS
+	w.mix_rate = SAMPLE_RATE
+	w.stereo = false
+	w.data = samples
+	return w

--- a/godot/scripts/core/audio/sfx_volume.gd
+++ b/godot/scripts/core/audio/sfx_volume.gd
@@ -1,0 +1,23 @@
+extends RefCounted
+## Helpers for wiring an AudioStreamPlayer to the master/SFX volume sliders
+## in `Settings`. Avoids each scene re-implementing the same volume math.
+
+const MIN_DB: float = -60.0
+
+
+## Combine master and sfx (each 0..1) into the effective linear volume.
+static func linear_volume(master: float, sfx: float) -> float:
+	return clamp(master * sfx, 0.0, 1.0)
+
+
+static func set_player_volume(player: AudioStreamPlayer, linear: float) -> void:
+	if linear <= 0.0:
+		player.volume_db = MIN_DB
+	else:
+		player.volume_db = linear_to_db(clamp(linear, 0.0, 1.0))
+
+
+static func linear_to_db(v: float) -> float:
+	if v <= 0.0001:
+		return MIN_DB
+	return 20.0 * log(v) / log(10.0)

--- a/godot/scripts/core/input/action_map_defaults.gd
+++ b/godot/scripts/core/input/action_map_defaults.gd
@@ -5,7 +5,7 @@ extends Object
 const ACTIONS: Array[StringName] = [
 	&"move_left", &"move_right", &"move_up", &"move_down",
 	&"soft_drop", &"hard_drop",
-	&"rotate_cw", &"rotate_ccw", &"hold", &"pause",
+	&"rotate_cw", &"rotate_ccw", &"hold", &"undo", &"pause",
 	&"ui_accept", &"ui_cancel",
 ]
 
@@ -27,6 +27,7 @@ const _DEFAULTS: Dictionary = {
 	&"rotate_cw":  [["kbd", KEY_UP], ["kbd", KEY_X],       ["pad", JOY_BUTTON_B]],
 	&"rotate_ccw": [["kbd", KEY_Z],                        ["pad", JOY_BUTTON_X]],
 	&"hold":       [["kbd", KEY_C], ["kbd", KEY_SHIFT],    ["pad", JOY_BUTTON_Y], ["pad", JOY_BUTTON_LEFT_SHOULDER]],
+	&"undo":       [["kbd", KEY_Z],                        ["pad", JOY_BUTTON_Y]],
 	&"pause":      [["kbd", KEY_ESCAPE], ["kbd", KEY_P],   ["pad", JOY_BUTTON_START]],
 	&"ui_accept":  [["kbd", KEY_ENTER], ["kbd", KEY_SPACE], ["pad", JOY_BUTTON_A]],
 	&"ui_cancel":  [["kbd", KEY_ESCAPE],                   ["pad", JOY_BUTTON_B]],

--- a/godot/scripts/core/input/haptics.gd
+++ b/godot/scripts/core/input/haptics.gd
@@ -1,0 +1,33 @@
+extends RefCounted
+## Cross-platform haptic pulse.
+##
+## Calls `Input.vibrate_handheld` on mobile (single-pad parameter accepted) and
+## `Input.start_joy_vibration` for the first connected gamepad. Both are no-ops
+## on headless / unsupported platforms, which is what we want for CI.
+##
+## `intensity` is 0..1 weak-rumble strength; `duration_ms` is how long.
+
+static func pulse(intensity: float, duration_ms: int) -> void:
+	intensity = clamp(intensity, 0.0, 1.0)
+	if intensity <= 0.0 or duration_ms <= 0:
+		return
+	# Mobile: handheld vibration only takes a duration.
+	Input.vibrate_handheld(duration_ms)
+	# Gamepad: pulse the first connected one. Pads still report on web exports;
+	# on platforms without rumble, the call is a documented no-op.
+	for id in Input.get_connected_joypads():
+		Input.start_joy_vibration(id, intensity * 0.6, intensity, float(duration_ms) / 1000.0)
+		break
+
+
+## Linear-interpolate intensity by `value`'s position in `tiers`. `tiers` is an
+## ordered list of (threshold, intensity, duration_ms) tuples; the first tier
+## whose `value < threshold` wins. The final tier is the cap (its threshold is
+## ignored — used as a fallback). Pure helper, no side effects.
+static func tier_for(value: int, tiers: Array) -> Dictionary:
+	for i in tiers.size() - 1:
+		var t: Array = tiers[i]
+		if value < int(t[0]):
+			return {"intensity": float(t[1]), "duration_ms": int(t[2])}
+	var last: Array = tiers[tiers.size() - 1]
+	return {"intensity": float(last[1]), "duration_ms": int(last[2])}

--- a/godot/tests/integration/test_g2048_polish.gd
+++ b/godot/tests/integration/test_g2048_polish.gd
@@ -1,0 +1,146 @@
+extends GutTest
+## 2048 scene polish tests (#21): undo round-trip, undo gating, best-score
+## persistence across scene reloads.
+
+const ActionMapDefaults := preload("res://scripts/core/input/action_map_defaults.gd")
+const Game2048State := preload("res://scripts/g2048/core/g2048_state.gd")
+
+const SEED: int = 4242
+
+var scene: Control
+
+
+func _settings() -> Node:
+	return Engine.get_main_loop().root.get_node("Settings")
+
+
+func before_each() -> void:
+	for action in ActionMapDefaults.ACTIONS:
+		Input.action_release(action)
+	_settings().reset_defaults()
+	# Wipe the persisted best-score key so each test starts from zero.
+	_settings().set_value(&"g2048.best", 0)
+	await get_tree().process_frame
+	var packed: PackedScene = load("res://scenes/g2048/g2048.tscn")
+	scene = packed.instantiate()
+	add_child(scene)
+	await get_tree().process_frame
+	scene.start(SEED)
+	await get_tree().process_frame
+
+
+func after_each() -> void:
+	for action in ActionMapDefaults.ACTIONS:
+		Input.action_release(action)
+	if is_instance_valid(scene):
+		scene.queue_free()
+	_settings().reset_defaults()
+	await get_tree().process_frame
+
+
+func _drain(max_frames: int = 40) -> void:
+	for _i in max_frames:
+		if scene._input_gate_open:
+			return
+		await get_tree().process_frame
+
+
+# Drive a sequence of move directions until at least one of them produces a
+# non-empty plan (i.e. score-changing). Returns true if a real move happened.
+func _make_a_real_move() -> bool:
+	for action in [&"move_left", &"move_up", &"move_right", &"move_down"]:
+		var before: Dictionary = scene.state.snapshot()
+		Input.action_press(action)
+		await get_tree().process_frame
+		await get_tree().process_frame
+		Input.action_release(action)
+		await get_tree().process_frame
+		await _drain()
+		var after: Dictionary = scene.state.snapshot()
+		if before["grid"] != after["grid"]:
+			return true
+	return false
+
+
+# --- Acceptance #4 / #5: undo round-trip, gating ---
+
+
+func test_undo_disabled_before_first_move() -> void:
+	assert_false(scene._can_undo(), "undo should not be available before a move")
+	# HUD button is disabled by start().
+	var btn: Button = scene.hud._undo_button
+	assert_true(btn.disabled, "HUD undo button starts disabled")
+
+
+func test_undo_round_trip_restores_grid_score_and_ids() -> void:
+	var before: Dictionary = scene.state.snapshot()
+	var moved: bool = await _make_a_real_move()
+	assert_true(moved, "test setup expected at least one of LRUD to move")
+	var mid: Dictionary = scene.state.snapshot()
+	assert_ne(before["grid"], mid["grid"], "grid changed after move")
+	assert_true(scene._can_undo())
+	scene._on_undo_invoked()
+	await get_tree().process_frame
+	var after: Dictionary = scene.state.snapshot()
+	# Acceptance #4: grid + score + ids exactly match the pre-move snapshot.
+	assert_eq(after["grid"], before["grid"], "undo restores grid + ids")
+	assert_eq(after["score"], before["score"], "undo restores score")
+	assert_false(scene._can_undo(), "undo charge consumed after use")
+
+
+func test_undo_charge_refills_after_next_real_move() -> void:
+	assert_true(await _make_a_real_move())
+	scene._on_undo_invoked()
+	await get_tree().process_frame
+	assert_false(scene._can_undo())
+	# Make another real move; charge refills.
+	assert_true(await _make_a_real_move())
+	assert_true(scene._can_undo(), "undo refills after a non-empty commit")
+
+
+func test_undo_blocked_during_animation_gate() -> void:
+	# Kick off a move, then before draining, _can_undo should be false because
+	# _input_gate_open is closed during the slide.
+	for action in [&"move_left", &"move_up", &"move_right", &"move_down"]:
+		Input.action_press(action)
+		await get_tree().process_frame
+		await get_tree().process_frame
+		Input.action_release(action)
+		await get_tree().process_frame
+		# Loop until a real move closes the gate.
+		if not scene._input_gate_open:
+			break
+	if not scene._input_gate_open:
+		assert_false(scene._can_undo(), "no undo during animation")
+		await _drain()
+
+
+# --- Acceptance #3: best score survives restart ---
+
+
+func test_best_score_persists_across_scene_restart() -> void:
+	assert_true(await _make_a_real_move())
+	var first_score: int = int(scene.state.snapshot().get("score", 0))
+	# Force best to a known value (>= current score) to detach from RNG.
+	_settings().set_value(&"g2048.best", max(first_score, 100))
+	# Tear down and rebuild the scene.
+	scene.queue_free()
+	await get_tree().process_frame
+	var packed: PackedScene = load("res://scenes/g2048/g2048.tscn")
+	scene = packed.instantiate()
+	add_child(scene)
+	await get_tree().process_frame
+	scene.start(SEED + 1)
+	await get_tree().process_frame
+	# Best label should reflect the persisted value, not 0.
+	assert_eq(scene._best_score, max(first_score, 100))
+
+
+func test_best_score_only_grows() -> void:
+	_settings().set_value(&"g2048.best", 9999)
+	scene.start(SEED)
+	await get_tree().process_frame
+	# A real move's score will be much smaller than 9999; best must not regress.
+	assert_true(await _make_a_real_move())
+	assert_eq(scene._best_score, 9999, "best does not decrease")
+	assert_eq(int(_settings().get_value(&"g2048.best", 0)), 9999)

--- a/godot/tests/unit/core/test_audio_haptics.gd
+++ b/godot/tests/unit/core/test_audio_haptics.gd
@@ -1,0 +1,70 @@
+extends GutTest
+## Pure helper tests for Haptics.tier_for + SfxTones tone synthesis.
+
+const Haptics := preload("res://scripts/core/input/haptics.gd")
+const SfxTones := preload("res://scripts/core/audio/sfx_tones.gd")
+const SfxVolume := preload("res://scripts/core/audio/sfx_volume.gd")
+
+
+func _tiers() -> Array:
+	return [
+		[16,    0.2,  60],
+		[128,   0.4, 100],
+		[1024,  0.6, 140],
+		[INF,   0.9, 200],
+	]
+
+
+func test_tier_for_low_value_picks_first_tier() -> void:
+	var t: Dictionary = Haptics.tier_for(8, _tiers())
+	assert_almost_eq(float(t["intensity"]), 0.2, 0.001)
+	assert_eq(int(t["duration_ms"]), 60)
+
+
+func test_tier_for_mid_value_picks_middle_tier() -> void:
+	var t: Dictionary = Haptics.tier_for(64, _tiers())
+	assert_almost_eq(float(t["intensity"]), 0.4, 0.001)
+
+
+func test_tier_for_threshold_boundary_picks_next_tier() -> void:
+	# value == threshold → NOT < threshold; picks next tier up.
+	var t: Dictionary = Haptics.tier_for(16, _tiers())
+	assert_almost_eq(float(t["intensity"]), 0.4, 0.001)
+
+
+func test_tier_for_huge_value_picks_cap() -> void:
+	var t: Dictionary = Haptics.tier_for(2048, _tiers())
+	assert_almost_eq(float(t["intensity"]), 0.9, 0.001)
+	assert_eq(int(t["duration_ms"]), 200)
+
+
+func test_tone_produces_correct_byte_length() -> void:
+	var w: AudioStreamWAV = SfxTones.tone(440.0, 0.05, 0.5)
+	# 22050 Hz × 0.05s × 2 bytes/sample = 2205 bytes.
+	assert_eq(w.data.size(), 2205)
+	assert_eq(w.format, AudioStreamWAV.FORMAT_16_BITS)
+	assert_eq(w.mix_rate, SfxTones.SAMPLE_RATE)
+
+
+func test_tone_sequence_concatenates_durations() -> void:
+	var w: AudioStreamWAV = SfxTones.tone_sequence([
+		Vector2(440.0, 0.05),
+		Vector2(660.0, 0.10),
+	])
+	# (0.05 + 0.10) × 22050 × 2 = 6615 bytes.
+	assert_eq(w.data.size(), 6615)
+
+
+func test_volume_clamps_and_combines() -> void:
+	assert_almost_eq(SfxVolume.linear_volume(1.0, 1.0), 1.0, 0.001)
+	assert_almost_eq(SfxVolume.linear_volume(0.5, 0.5), 0.25, 0.001)
+	# Out-of-range inputs clamp.
+	assert_almost_eq(SfxVolume.linear_volume(2.0, 0.5), 1.0, 0.001)
+	assert_almost_eq(SfxVolume.linear_volume(-1.0, 0.5), 0.0, 0.001)
+
+
+func test_volume_zero_emits_min_db() -> void:
+	var p := AudioStreamPlayer.new()
+	add_child_autofree(p)
+	SfxVolume.set_player_volume(p, 0.0)
+	assert_almost_eq(p.volume_db, SfxVolume.MIN_DB, 0.01)

--- a/godot/tests/unit/core/test_audio_haptics.gd
+++ b/godot/tests/unit/core/test_audio_haptics.gd
@@ -40,8 +40,9 @@ func test_tier_for_huge_value_picks_cap() -> void:
 
 func test_tone_produces_correct_byte_length() -> void:
 	var w: AudioStreamWAV = SfxTones.tone(440.0, 0.05, 0.5)
-	# 22050 Hz × 0.05s × 2 bytes/sample = 2205 bytes.
-	assert_eq(w.data.size(), 2205)
+	# n samples = int(0.05 * 22050) = 1102; 16-bit mono = 2 bytes/sample.
+	var n: int = int(0.05 * SfxTones.SAMPLE_RATE)
+	assert_eq(w.data.size(), n * 2)
 	assert_eq(w.format, AudioStreamWAV.FORMAT_16_BITS)
 	assert_eq(w.mix_rate, SfxTones.SAMPLE_RATE)
 
@@ -51,8 +52,9 @@ func test_tone_sequence_concatenates_durations() -> void:
 		Vector2(440.0, 0.05),
 		Vector2(660.0, 0.10),
 	])
-	# (0.05 + 0.10) × 22050 × 2 = 6615 bytes.
-	assert_eq(w.data.size(), 6615)
+	# Sum of int(dur * rate) per step, doubled for 2 bytes/sample.
+	var total_n: int = int(0.05 * SfxTones.SAMPLE_RATE) + int(0.10 * SfxTones.SAMPLE_RATE)
+	assert_eq(w.data.size(), total_n * 2)
 
 
 func test_volume_clamps_and_combines() -> void:


### PR DESCRIPTION
Closes #21

## How tested
- GUT tests pass locally in worktree (350/350 green).
- New `tests/integration/test_g2048_polish.gd` covers undo round-trip (grid + score + tile-id layout), undo gating (before first move, during animation, after consumption + refill), and best-score persistence across scene reload + monotonicity.
- New `tests/unit/core/test_audio_haptics.gd` covers `Haptics.tier_for` (low / boundary / mid / cap), `SfxTones.tone` + `tone_sequence` byte-length math, and `SfxVolume.linear_volume` clamp/combine + min-dB floor.

## Notes
- Procedurally synthesizes SFX via `AudioStreamWAV` at runtime — no binary OGG assets shipped, so headless CI stays asset-free.
- Adds the `undo` semantic action to `InputManager` defaults (Z keyboard, Y / Triangle pad). Decoupled from `hold` per PRD; key/button overlap with `rotate_ccw` and `hold` is harmless because no single scene listens for both action sets.
- `g2048.best` key honored from `docs/persistence.md` table. Best persists via the existing `Settings` autoload's debounced `ConfigFile` writer.

## Estimated effective diff
371 lines (total 592, excluded 221).