### PR TITLE
feat(invaders): scene + fire action + touch + integration tests

### DIFF
--- a/docs/input-mapping.md
+++ b/docs/input-mapping.md
@@ -12,6 +12,7 @@ The `InputManager` autoload (added in task #2) exposes **semantic actions** so g
 | `move_down`  | ↓ / S          | D-pad ↓                | D-pad ↓            | Swipe ↓ |
 | `soft_drop`  | ↓ / S          | D-pad ↓                | D-pad ↓            | Hold-down zone |
 | `hard_drop`  | Space          | A                      | Cross              | Tap-up zone    |
+| `fire`       | Space / J      | A                      | Cross              | On-screen FIRE button |
 | `rotate_cw`  | ↑ / X          | B                      | Circle             | Right-half tap |
 | `rotate_ccw` | Z              | X                      | Square             | Left-half tap  |
 | `hold`       | C / Shift      | Y / LB                 | Triangle / L1      | Two-finger tap |
@@ -21,6 +22,14 @@ The `InputManager` autoload (added in task #2) exposes **semantic actions** so g
 `move_up` and `move_down` are semantic 4-direction equivalents of `move_left`/`move_right` for grid-based games (Snake, 2048). They intentionally share keys with `rotate_cw` (↑) and `soft_drop` (↓); per-game scenes consume only the actions they care about, so the overlap is harmless.
 
 `undo` shares its keyboard default (Z) with `rotate_ccw` and its gamepad default (Y / Triangle) with `hold`. Same rationale: 2048 listens for `undo`, Tetris listens for `rotate_ccw` / `hold` — actions don't compete unless a single scene subscribes to both, which none do.
+
+### Cross-action duplicate bindings are allowed
+
+Multiple semantic actions may share the same physical input by design. Example: `fire` (Invaders) and `hard_drop` (Tetris) both default to `Space` / `A`. Only the scene that's loaded subscribes to its action's signal, so there's no conflict at runtime. The rebind UI (task #5b) **must permit cross-action duplicates** when the user assigns the same key to two actions; it's a feature, not a misconfiguration.
+
+### Touch UX may differ per game by design
+
+Action names are stable across games, but the touch surface that produces them is not. `hard_drop` in Tetris is a tap-up zone over the playfield; `fire` in Invaders is a dedicated on-screen FIRE button in the bottom-right corner. Each scene picks the gesture that fits its play model — there's no requirement to converge.
 
 ## DAS / ARR (auto repeat)
 

--- a/godot/scenes/invaders/invaders.gd
+++ b/godot/scenes/invaders/invaders.gd
@@ -1,0 +1,451 @@
+extends Control
+## Invaders top-level scene. Wires InputManager → InvadersGameState → view layers.
+##
+## Implements the GameHost duck-typed contract (start/pause/resume/teardown +
+## exit_requested / score_reported signals). Mirrors the breakout/snake/2048
+## scene pattern.
+##
+## Render model: each view layer (formation, bunkers, player, bullets, ufo,
+## explosions) is its own Node2D drawing in world units (config.world_w ×
+## world_h). The BoardHost Control applies a uniform fit-letterbox transform
+## on every viewport resize.
+##
+## Sub-step time: per the Dev plan, the scene must NOT call state.tick()
+## while the wave-cleared interlude is on screen. set_last_tick(now_ms) is
+## called on resume / interlude exit / focus-in to prevent the sim from
+## auto-stepping the missed wall-clock window.
+
+const InvadersConfig := preload("res://scripts/invaders/core/invaders_config.gd")
+const InvadersLevel := preload("res://scripts/invaders/core/invaders_level.gd")
+const InvadersGameState := preload("res://scripts/invaders/core/invaders_state.gd")
+const Palette := preload("res://scripts/invaders/invaders_palette.gd")
+const FormationLayer := preload("res://scenes/invaders/view/formation_layer.gd")
+const BunkersLayer := preload("res://scenes/invaders/view/bunkers_layer.gd")
+const PlayerLayer := preload("res://scenes/invaders/view/player_layer.gd")
+const BulletsLayer := preload("res://scenes/invaders/view/bullets_layer.gd")
+const UfoLayer := preload("res://scenes/invaders/view/ufo_layer.gd")
+const ExplosionLayer := preload("res://scenes/invaders/view/explosion_layer.gd")
+const HUD := preload("res://scenes/invaders/view/hud.gd")
+const PauseOverlay := preload("res://scenes/invaders/view/pause_overlay.gd")
+const WaveInterlude := preload("res://scenes/invaders/view/wave_interlude.gd")
+const GameOverOverlay := preload("res://scenes/invaders/view/game_over_overlay.gd")
+const FireButton := preload("res://scenes/invaders/view/fire_button.gd")
+
+# GameHost contract.
+signal exit_requested()
+signal score_reported(value: int)
+
+const WAVE_INTERLUDE_MS: int = 1200
+const TOUCH_DRAG_ZONE_FRACTION: float = 0.6   # left 60% of playfield
+const TOUCH_DRAG_LERP_FACTOR: float = 0.35
+
+enum Phase { PLAYING, PAUSED, INTERLUDE, GAME_OVER }
+
+@onready var board_host: Control = $BoardHost
+@onready var formation_layer: Node2D = $BoardHost/FormationLayer
+@onready var bunkers_layer: Node2D = $BoardHost/BunkersLayer
+@onready var player_layer: Node2D = $BoardHost/PlayerLayer
+@onready var bullets_layer: Node2D = $BoardHost/BulletsLayer
+@onready var ufo_layer: Node2D = $BoardHost/UfoLayer
+@onready var explosion_layer: Node2D = $BoardHost/ExplosionLayer
+@onready var hud: Control = $HUD
+@onready var pause_overlay: CanvasLayer = $PauseOverlay
+@onready var wave_interlude: CanvasLayer = $WaveInterlude
+@onready var game_over_overlay: CanvasLayer = $GameOverOverlay
+@onready var fire_button: Control = $FireButton
+
+var state: InvadersGameState
+var config: InvadersConfig
+var level: InvadersLevel
+var _phase: int = Phase.PLAYING
+var _logical_now_ms: int = 0
+var _last_real_ms: int = 0
+var _started: bool = false
+var _last_reported_score: int = -1
+var _seed: int = 0
+
+# Wave-interlude (real-time, not core time).
+var _interlude_until_real_ms: int = -1
+var _last_drawn_wave: int = 1
+
+# Snapshot diff tracking — drives selective layer redraws + score-popup detection.
+var _prev_snap: Dictionary = {}
+var _last_formation_step_ms: int = 0
+var _formation_pose: int = Palette.MARCH_POSE_A
+var _last_bunker_hash: int = 0
+var _last_ufo_present: bool = false
+var _last_ufo_x: float = 0.0
+var _last_score: int = 0
+
+# Touch tracking.
+var _drag_touch_index: int = -1
+var _touch_target_x: float = -1.0   # world coord; -1 = no active drag
+
+# Cached letterbox transform.
+var _world_to_local_scale: float = 1.0
+var _world_to_local_offset: Vector2 = Vector2.ZERO
+
+
+func _ready() -> void:
+	pause_overlay.visible = false
+	wave_interlude.visible = false
+	game_over_overlay.visible = false
+	InputManager.action_pressed.connect(_on_action_pressed)
+	game_over_overlay.restart_requested.connect(_on_restart_pressed)
+	game_over_overlay.menu_requested.connect(_on_menu_pressed)
+	pause_overlay.menu_requested.connect(_on_menu_pressed)
+	fire_button.fire_requested.connect(_on_fire_pressed)
+	board_host.resized.connect(_recompute_letterbox)
+	# Standalone launch: auto-start with deterministic seed 0.
+	if get_tree().current_scene == self:
+		start(0)
+
+
+# --- GameHost contract ---
+
+func start(seed_value: int = 0) -> void:
+	_seed = seed_value
+	config = InvadersConfig.new()
+	level = InvadersLevel.new()
+	state = InvadersGameState.create(_seed, config, level)
+	if state == null:
+		push_error("Invaders: failed to create state (tunneling cap?)")
+		return
+	_phase = Phase.PLAYING
+	_logical_now_ms = 0
+	_last_real_ms = _real_now()
+	_last_reported_score = -1
+	_interlude_until_real_ms = -1
+	_drag_touch_index = -1
+	_touch_target_x = -1.0
+	_prev_snap = state.snapshot()
+	_last_drawn_wave = int(_prev_snap.get("wave", 1))
+	_last_formation_step_ms = int((_prev_snap.get("formation", {}) as Dictionary).get("last_step_ms", 0))
+	_formation_pose = Palette.MARCH_POSE_A
+	_last_bunker_hash = _hash_bunkers(_prev_snap)
+	_last_ufo_present = _prev_snap.get("ufo", null) != null
+	_last_ufo_x = float((_prev_snap.get("ufo", {}) as Dictionary).get("x", 0.0)) if _last_ufo_present else 0.0
+	_last_score = int(_prev_snap.get("score", 0))
+	_configure_layers()
+	pause_overlay.visible = false
+	wave_interlude.visible = false
+	game_over_overlay.visible = false
+	_started = true
+	_recompute_letterbox()
+	_redraw_all(_prev_snap)
+
+
+func pause() -> void:
+	if _phase == Phase.PLAYING:
+		_phase = Phase.PAUSED
+		pause_overlay.visible = true
+
+
+func resume() -> void:
+	if _phase == Phase.PAUSED:
+		_phase = Phase.PLAYING
+		pause_overlay.visible = false
+		_last_real_ms = _real_now()
+		# Don't auto-step the missed wall-clock window.
+		if state != null:
+			state.set_last_tick(_logical_now_ms)
+
+
+func teardown() -> void:
+	if InputManager.action_pressed.is_connected(_on_action_pressed):
+		InputManager.action_pressed.disconnect(_on_action_pressed)
+	state = null
+	config = null
+	level = null
+	_started = false
+
+
+# --- Loop ---
+
+func _process(_delta: float) -> void:
+	if not _started or state == null:
+		return
+	var real_now: int = _real_now()
+	var dt: int = max(0, real_now - _last_real_ms)
+	_last_real_ms = real_now
+	if _phase == Phase.PAUSED or _phase == Phase.GAME_OVER:
+		return
+	# Wave-cleared interlude: render the current snapshot but DO NOT call tick.
+	if _phase == Phase.INTERLUDE:
+		if real_now >= _interlude_until_real_ms:
+			_phase = Phase.PLAYING
+			wave_interlude.visible = false
+			# Re-anchor sim so it doesn't auto-step the interlude window.
+			state.set_last_tick(_logical_now_ms + dt)
+		_logical_now_ms += dt
+		return
+	_logical_now_ms += dt
+	# Compute player intent from input + touch.
+	var intent_x: float = _compute_player_intent_norm()
+	state.set_player_intent(intent_x * config.player_max_speed_px_s)
+	var changed: bool = state.tick(_logical_now_ms)
+	if changed:
+		_update_views()
+	if state.is_game_over() and _phase != Phase.GAME_OVER:
+		_enter_game_over()
+
+
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_APPLICATION_FOCUS_IN:
+		_last_real_ms = _real_now()
+		if state != null and (_phase == Phase.PLAYING or _phase == Phase.INTERLUDE):
+			state.set_last_tick(_logical_now_ms)
+
+
+# --- Player intent ---
+
+func _compute_player_intent_norm() -> float:
+	# Touch drag overrides if active.
+	if _touch_target_x >= 0.0 and state != null:
+		var dx: float = _touch_target_x - state.player_x
+		if absf(dx) < 0.5:
+			return 0.0
+		return clampf(dx / config.player_max_speed_px_s * 2.0, -1.0, 1.0)
+	var right: float = Input.get_action_strength(&"move_right")
+	var left: float = Input.get_action_strength(&"move_left")
+	return clampf(right - left, -1.0, 1.0)
+
+
+# --- View ---
+
+func _configure_layers() -> void:
+	formation_layer.configure(config, level)
+	bunkers_layer.configure(config, level)
+	player_layer.configure(config)
+	bullets_layer.configure(config)
+	ufo_layer.configure(config)
+	explosion_layer.configure(config)
+	hud.configure(config)
+
+
+func _redraw_all(snap: Dictionary) -> void:
+	formation_layer.update_from_snapshot(snap, _formation_pose)
+	bunkers_layer.update_from_snapshot(snap)
+	player_layer.update_from_snapshot(snap)
+	bullets_layer.update_from_snapshot(snap)
+	ufo_layer.update_from_snapshot(snap)
+	hud.update_from_snapshot(snap)
+
+
+func _update_views() -> void:
+	if state == null:
+		return
+	var snap: Dictionary = state.snapshot()
+	# Wave change → trigger interlude before letting the next-wave snapshot animate.
+	var wave: int = int(snap.get("wave", 1))
+	if wave != _last_drawn_wave:
+		_last_drawn_wave = wave
+		_enter_wave_interlude(wave)
+	# Formation step?
+	var fm: Dictionary = snap.get("formation", {})
+	var step_ms: int = int(fm.get("last_step_ms", 0))
+	# `last_step_ms` is set to set_last_tick on initialize/wave/resume, so we
+	# explicitly toggle pose on a real formation cell motion: detect via the
+	# sub-step accumulator change indirectly — easier: detect via formation
+	# origin change OR live_mask change. Snapshot ox/oy + dir together.
+	var prev_fm: Dictionary = _prev_snap.get("formation", {})
+	var formation_moved: bool = (
+		fm.get("ox", 0.0) != prev_fm.get("ox", 0.0)
+		or fm.get("oy", 0.0) != prev_fm.get("oy", 0.0)
+		or fm.get("dir", 0) != prev_fm.get("dir", 0)
+	)
+	# Enemy mask change forces formation redraw too (kill animation).
+	var enemy_mask_changed: bool = not _packed_byte_eq(snap.get("enemies", PackedByteArray()), _prev_snap.get("enemies", PackedByteArray()))
+	if formation_moved:
+		_formation_pose = Palette.MARCH_POSE_B if _formation_pose == Palette.MARCH_POSE_A else Palette.MARCH_POSE_A
+		formation_layer.update_from_snapshot(snap, _formation_pose)
+	elif enemy_mask_changed:
+		formation_layer.update_from_snapshot(snap, _formation_pose)
+	_last_formation_step_ms = step_ms
+	# Bunkers redraw on diff.
+	var bhash: int = _hash_bunkers(snap)
+	if bhash != _last_bunker_hash:
+		_last_bunker_hash = bhash
+		bunkers_layer.update_from_snapshot(snap)
+	# Player + bullets redraw every frame (cheap).
+	player_layer.update_from_snapshot(snap)
+	bullets_layer.update_from_snapshot(snap)
+	# UFO + score popup.
+	var ufo_present: bool = snap.get("ufo", null) != null
+	var score: int = int(snap.get("score", 0))
+	if ufo_present != _last_ufo_present or ufo_present:
+		ufo_layer.update_from_snapshot(snap)
+	# UFO killed this tick = ufo went null AND score increased: scene-only popup.
+	if _last_ufo_present and not ufo_present and score > _last_score:
+		ufo_layer.spawn_score_popup(_last_ufo_x, score - _last_score)
+	if ufo_present:
+		_last_ufo_x = float((snap.get("ufo", {}) as Dictionary).get("x", _last_ufo_x))
+	_last_ufo_present = ufo_present
+	_last_score = score
+	hud.update_from_snapshot(snap)
+	_prev_snap = snap
+	if score != _last_reported_score:
+		_last_reported_score = score
+		score_reported.emit(score)
+
+
+static func _packed_byte_eq(a: Variant, b: Variant) -> bool:
+	if not (a is PackedByteArray) or not (b is PackedByteArray):
+		return false
+	var pa: PackedByteArray = a
+	var pb: PackedByteArray = b
+	if pa.size() != pb.size():
+		return false
+	for i in range(pa.size()):
+		if pa[i] != pb[i]:
+			return false
+	return true
+
+
+static func _hash_bunkers(snap: Dictionary) -> int:
+	# Cheap rolling hash over each bunker's PackedByteArray. Cells flip rarely
+	# (only on bullet hit), so any change reliably moves the hash.
+	var bgs: Array = snap.get("bunkers", [])
+	var h: int = 0x12345678
+	for bg in bgs:
+		if bg is PackedByteArray:
+			var pa: PackedByteArray = bg
+			# Hash by xor'ing every 4-byte chunk into h. Cheap and good enough.
+			var i: int = 0
+			while i < pa.size():
+				var w: int = pa[i]
+				if i + 1 < pa.size(): w |= pa[i + 1] << 8
+				if i + 2 < pa.size(): w |= pa[i + 2] << 16
+				if i + 3 < pa.size(): w |= pa[i + 3] << 24
+				h = ((h << 5) | (h >> 27)) ^ w
+				i += 4
+	return h
+
+
+# --- Letterbox ---
+
+func _recompute_letterbox() -> void:
+	if config == null:
+		return
+	var avail: Vector2 = board_host.size
+	if avail.x <= 0.0 or avail.y <= 0.0:
+		return
+	var sx: float = avail.x / config.world_w
+	var sy: float = avail.y / config.world_h
+	var s: float = minf(sx, sy)
+	var used: Vector2 = Vector2(config.world_w, config.world_h) * s
+	var off: Vector2 = (avail - used) * 0.5
+	_world_to_local_scale = s
+	_world_to_local_offset = off
+	for layer in [formation_layer, bunkers_layer, player_layer, bullets_layer, ufo_layer, explosion_layer]:
+		if layer != null:
+			layer.position = off
+			layer.scale = Vector2(s, s)
+
+
+func _local_to_world(local: Vector2) -> Vector2:
+	if _world_to_local_scale <= 0.0:
+		return Vector2.ZERO
+	return (local - _world_to_local_offset) / _world_to_local_scale
+
+
+# --- Input: action signals ---
+
+func _on_action_pressed(action: StringName) -> void:
+	if action == &"pause":
+		_toggle_pause()
+		return
+	if _phase != Phase.PLAYING:
+		return
+	if state == null:
+		return
+	if action == &"fire":
+		state.fire()
+
+
+func _on_fire_pressed() -> void:
+	if _phase != Phase.PLAYING or state == null:
+		return
+	state.fire()
+
+
+# --- Input: touch (drag zone in left 60% of playfield) ---
+
+func _unhandled_input(event: InputEvent) -> void:
+	if event is InputEventScreenTouch:
+		_handle_touch(event as InputEventScreenTouch)
+	elif event is InputEventScreenDrag:
+		_handle_drag(event as InputEventScreenDrag)
+
+
+func _handle_touch(t: InputEventScreenTouch) -> void:
+	if _phase != Phase.PLAYING:
+		return
+	var w: Vector2 = _local_to_world(board_host.to_local(t.position))
+	var in_drag_zone: bool = w.x >= 0.0 and w.x <= config.world_w * TOUCH_DRAG_ZONE_FRACTION \
+			and w.y >= 0.0 and w.y <= config.world_h
+	if t.pressed:
+		if _drag_touch_index == -1 and in_drag_zone:
+			_drag_touch_index = t.index
+			_touch_target_x = clampf(w.x, 0.0, config.world_w)
+	else:
+		if t.index == _drag_touch_index:
+			_drag_touch_index = -1
+			_touch_target_x = -1.0
+
+
+func _handle_drag(d: InputEventScreenDrag) -> void:
+	if d.index != _drag_touch_index:
+		return
+	if _phase != Phase.PLAYING:
+		return
+	var w: Vector2 = _local_to_world(board_host.to_local(d.position))
+	_touch_target_x = clampf(w.x, 0.0, config.world_w)
+
+
+# --- Phase transitions ---
+
+func _toggle_pause() -> void:
+	if _phase == Phase.PLAYING:
+		pause()
+	elif _phase == Phase.PAUSED:
+		resume()
+
+
+func _enter_wave_interlude(new_wave: int) -> void:
+	_phase = Phase.INTERLUDE
+	wave_interlude.show_with(new_wave)
+	_interlude_until_real_ms = _real_now() + WAVE_INTERLUDE_MS
+
+
+func _enter_game_over() -> void:
+	_phase = Phase.GAME_OVER
+	wave_interlude.visible = false
+	var snap: Dictionary = state.snapshot() if state != null else {}
+	game_over_overlay.show_with(int(snap.get("score", 0)), int(snap.get("wave", 1)))
+
+
+func _on_restart_pressed() -> void:
+	game_over_overlay.visible = false
+	# Bump seed for variety on retry.
+	_seed = _seed + 1
+	start(_seed)
+
+
+func _on_menu_pressed() -> void:
+	exit_requested.emit()
+
+
+func _real_now() -> int:
+	return Time.get_ticks_msec()
+
+
+# --- Test seam ---
+
+## Force a snapshot redraw bypass; used by scene tests to assert layer state
+## after directly mutating `state` outside the normal _process loop.
+func _refresh_views_for_test() -> void:
+	if state == null:
+		return
+	_prev_snap = state.snapshot()
+	_redraw_all(_prev_snap)

--- a/godot/scenes/invaders/invaders.gd.uid
+++ b/godot/scenes/invaders/invaders.gd.uid
@@ -1,0 +1,1 @@
+uid://el4x3nolrqhl

--- a/godot/scenes/invaders/invaders.tscn
+++ b/godot/scenes/invaders/invaders.tscn
@@ -1,0 +1,60 @@
+[gd_scene load_steps=14 format=3 uid="uid://binvadersroot01"]
+
+[ext_resource type="Script" path="res://scenes/invaders/invaders.gd" id="1_root"]
+[ext_resource type="Script" path="res://scenes/invaders/view/formation_layer.gd" id="2_formation"]
+[ext_resource type="Script" path="res://scenes/invaders/view/bunkers_layer.gd" id="3_bunkers"]
+[ext_resource type="Script" path="res://scenes/invaders/view/player_layer.gd" id="4_player"]
+[ext_resource type="Script" path="res://scenes/invaders/view/bullets_layer.gd" id="5_bullets"]
+[ext_resource type="Script" path="res://scenes/invaders/view/ufo_layer.gd" id="6_ufo"]
+[ext_resource type="Script" path="res://scenes/invaders/view/explosion_layer.gd" id="7_explosion"]
+[ext_resource type="Script" path="res://scenes/invaders/view/hud.gd" id="8_hud"]
+[ext_resource type="Script" path="res://scenes/invaders/view/pause_overlay.gd" id="9_pause"]
+[ext_resource type="Script" path="res://scenes/invaders/view/wave_interlude.gd" id="10_interlude"]
+[ext_resource type="Script" path="res://scenes/invaders/view/game_over_overlay.gd" id="11_over"]
+[ext_resource type="Script" path="res://scenes/invaders/view/fire_button.gd" id="12_fire"]
+
+[node name="Invaders" type="Control"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource("1_root")
+
+[node name="BoardHost" type="Control" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="FormationLayer" type="Node2D" parent="BoardHost"]
+script = ExtResource("2_formation")
+
+[node name="BunkersLayer" type="Node2D" parent="BoardHost"]
+script = ExtResource("3_bunkers")
+
+[node name="PlayerLayer" type="Node2D" parent="BoardHost"]
+script = ExtResource("4_player")
+
+[node name="BulletsLayer" type="Node2D" parent="BoardHost"]
+script = ExtResource("5_bullets")
+
+[node name="UfoLayer" type="Node2D" parent="BoardHost"]
+script = ExtResource("6_ufo")
+
+[node name="ExplosionLayer" type="Node2D" parent="BoardHost"]
+script = ExtResource("7_explosion")
+
+[node name="HUD" type="Control" parent="."]
+anchors_preset = 10
+anchor_right = 1.0
+script = ExtResource("8_hud")
+
+[node name="FireButton" type="Control" parent="."]
+script = ExtResource("12_fire")
+
+[node name="PauseOverlay" type="CanvasLayer" parent="."]
+script = ExtResource("9_pause")
+
+[node name="WaveInterlude" type="CanvasLayer" parent="."]
+script = ExtResource("10_interlude")
+
+[node name="GameOverOverlay" type="CanvasLayer" parent="."]
+script = ExtResource("11_over")

--- a/godot/scenes/invaders/view/bullets_layer.gd
+++ b/godot/scenes/invaders/view/bullets_layer.gd
@@ -1,0 +1,40 @@
+extends Node2D
+## Bullets renderer. Draws the player bullet (white, 2×6) and every enemy
+## bullet (2×6, color picked from a small palette by index). Redrawn every
+## frame; cost is dominated by enemy bullet count which is capped at ~10.
+
+const InvadersConfig := preload("res://scripts/invaders/core/invaders_config.gd")
+const Palette := preload("res://scripts/invaders/invaders_palette.gd")
+
+var _cfg: InvadersConfig
+var _snap: Dictionary = {}
+
+
+func configure(cfg: InvadersConfig) -> void:
+	_cfg = cfg
+	queue_redraw()
+
+
+func update_from_snapshot(snap: Dictionary) -> void:
+	_snap = snap
+	queue_redraw()
+
+
+func _draw() -> void:
+	if _cfg == null or _snap.is_empty():
+		return
+	var pb: Dictionary = _snap.get("player_bullet", {})
+	if bool(pb.get("alive", false)):
+		var x: float = float(pb.get("x", 0.0))
+		var y: float = float(pb.get("y", 0.0))
+		var hw: float = _cfg.player_bullet_w * 0.5
+		var hh: float = _cfg.player_bullet_h * 0.5
+		draw_rect(Rect2(Vector2(x - hw, y - hh), Vector2(_cfg.player_bullet_w, _cfg.player_bullet_h)), Palette.PLAYER_BULLET, true)
+	var ebs: Array = _snap.get("enemy_bullets", [])
+	for i in range(ebs.size()):
+		var b: Dictionary = ebs[i]
+		var bx: float = float(b.get("x", 0.0))
+		var by: float = float(b.get("y", 0.0))
+		var hw2: float = _cfg.enemy_bullet_w * 0.5
+		var hh2: float = _cfg.enemy_bullet_h * 0.5
+		draw_rect(Rect2(Vector2(bx - hw2, by - hh2), Vector2(_cfg.enemy_bullet_w, _cfg.enemy_bullet_h)), Palette.enemy_bullet_color(i), true)

--- a/godot/scenes/invaders/view/bullets_layer.gd.uid
+++ b/godot/scenes/invaders/view/bullets_layer.gd.uid
@@ -1,0 +1,1 @@
+uid://r8dwxlj4glvs

--- a/godot/scenes/invaders/view/bunkers_layer.gd
+++ b/godot/scenes/invaders/view/bunkers_layer.gd
@@ -1,0 +1,64 @@
+extends Node2D
+## Bunkers renderer. Each bunker is a grid of 1/0 cells; we draw one filled
+## rect per live cell, in BUNKER color. Redrawn only when the parent detects
+## a bunker diff (via hash compare on the snapshot's bunker arrays).
+
+const InvadersConfig := preload("res://scripts/invaders/core/invaders_config.gd")
+const InvadersLevel := preload("res://scripts/invaders/core/invaders_level.gd")
+const Palette := preload("res://scripts/invaders/invaders_palette.gd")
+
+var _cfg: InvadersConfig
+var _level: InvadersLevel
+var _snap: Dictionary = {}
+var _origins: Array = []   # Array[Vector2]; mirrors state.bunker_origins.
+
+
+func configure(cfg: InvadersConfig, lvl: InvadersLevel) -> void:
+	_cfg = cfg
+	_level = lvl
+	_compute_origins()
+	queue_redraw()
+
+
+func _compute_origins() -> void:
+	_origins = []
+	if _cfg == null or _level == null:
+		return
+	var bunker_world_w: float = _level.bunker_w_cells * _cfg.bunker_cell_w
+	var bunker_world_h: float = _level.bunker_h_cells * _cfg.bunker_cell_h
+	var total_w: float = _cfg.bunker_count * bunker_world_w
+	var gap: float = (_cfg.world_w - total_w) / float(_cfg.bunker_count + 1)
+	for i in range(_cfg.bunker_count):
+		var ox: float = gap + i * (bunker_world_w + gap)
+		var oy: float = _cfg.bunker_y - bunker_world_h * 0.5
+		_origins.append(Vector2(ox, oy))
+
+
+func update_from_snapshot(snap: Dictionary) -> void:
+	_snap = snap
+	queue_redraw()
+
+
+func _draw() -> void:
+	if _cfg == null or _level == null or _snap.is_empty():
+		return
+	var bgs: Array = _snap.get("bunkers", [])
+	var w: int = _level.bunker_w_cells
+	var h: int = _level.bunker_h_cells
+	var cw: float = _cfg.bunker_cell_w
+	var ch: float = _cfg.bunker_cell_h
+	for i in range(min(bgs.size(), _origins.size())):
+		var pa: Variant = bgs[i]
+		if not (pa is PackedByteArray):
+			continue
+		var cells: PackedByteArray = pa
+		if cells.size() < w * h:
+			continue
+		var origin: Vector2 = _origins[i]
+		for r in range(h):
+			for c in range(w):
+				if cells[r * w + c] != 1:
+					continue
+				var x: float = origin.x + c * cw
+				var y: float = origin.y + r * ch
+				draw_rect(Rect2(Vector2(x, y), Vector2(cw, ch)), Palette.BUNKER, true)

--- a/godot/scenes/invaders/view/bunkers_layer.gd.uid
+++ b/godot/scenes/invaders/view/bunkers_layer.gd.uid
@@ -1,0 +1,1 @@
+uid://dgc32h3qwf167

--- a/godot/scenes/invaders/view/explosion_layer.gd
+++ b/godot/scenes/invaders/view/explosion_layer.gd
@@ -1,0 +1,63 @@
+extends Node2D
+## One-shot pixel-burst explosions, scene-only and pooled. The parent triggers
+## a burst at a world position; we spawn ephemeral particle records and fade
+## them out over EXPLOSION_DURATION_MS via _draw. No timers per-burst — a
+## single _process drains expired records.
+
+const InvadersConfig := preload("res://scripts/invaders/core/invaders_config.gd")
+const Palette := preload("res://scripts/invaders/invaders_palette.gd")
+
+const EXPLOSION_DURATION_MS: int = 200
+const EXPLOSION_PARTICLE_COUNT: int = 8
+const EXPLOSION_PARTICLE_SIZE: float = 1.5
+const EXPLOSION_RADIUS: float = 6.0
+
+# Active bursts: Array of {x, y, t0_ms, particles: Array[Vector2]} where each
+# Vector2 is a unit-direction offset multiplied by EXPLOSION_RADIUS at peak.
+var _bursts: Array = []
+
+
+func configure(_cfg: InvadersConfig) -> void:
+	set_process(true)
+	queue_redraw()
+
+
+func spawn(world_x: float, world_y: float) -> void:
+	var rng := RandomNumberGenerator.new()
+	rng.randomize()
+	var particles: Array = []
+	for i in range(EXPLOSION_PARTICLE_COUNT):
+		var theta: float = rng.randf_range(0.0, TAU)
+		particles.append(Vector2(cos(theta), sin(theta)))
+	_bursts.append({"x": world_x, "y": world_y, "t0_ms": Time.get_ticks_msec(), "particles": particles})
+	queue_redraw()
+
+
+func _process(_delta: float) -> void:
+	if _bursts.is_empty():
+		return
+	var now: int = Time.get_ticks_msec()
+	var i: int = 0
+	while i < _bursts.size():
+		var b: Dictionary = _bursts[i]
+		if now - int(b["t0_ms"]) > EXPLOSION_DURATION_MS:
+			_bursts.remove_at(i)
+		else:
+			i += 1
+	queue_redraw()
+
+
+func _draw() -> void:
+	var now: int = Time.get_ticks_msec()
+	for b in _bursts:
+		var t: float = clampf(float(now - int(b["t0_ms"])) / float(EXPLOSION_DURATION_MS), 0.0, 1.0)
+		var radius: float = EXPLOSION_RADIUS * t
+		var alpha: float = 1.0 - t
+		var color := Color(Palette.EXPLOSION.r, Palette.EXPLOSION.g, Palette.EXPLOSION.b, alpha)
+		var bx: float = float(b["x"])
+		var by: float = float(b["y"])
+		for p in b["particles"]:
+			var pv: Vector2 = p
+			draw_rect(Rect2(Vector2(bx + pv.x * radius - EXPLOSION_PARTICLE_SIZE * 0.5,
+					by + pv.y * radius - EXPLOSION_PARTICLE_SIZE * 0.5),
+					Vector2(EXPLOSION_PARTICLE_SIZE, EXPLOSION_PARTICLE_SIZE)), color, true)

--- a/godot/scenes/invaders/view/explosion_layer.gd.uid
+++ b/godot/scenes/invaders/view/explosion_layer.gd.uid
@@ -1,0 +1,1 @@
+uid://cnawpq53a1v0e

--- a/godot/scenes/invaders/view/fire_button.gd
+++ b/godot/scenes/invaders/view/fire_button.gd
@@ -1,0 +1,56 @@
+extends Control
+## Touch-only on-screen FIRE button. Anchored bottom-right. Emits
+## `fire_requested` on tap-down. Calls `accept_event()` so the touch is not
+## also consumed by the parent's drag-zone tracker.
+##
+## On non-touch builds this is harmless: kbd / gamepad still routes `fire`
+## via the normal InputManager path.
+
+signal fire_requested()
+
+const SIZE_PX: float = 80.0
+const MARGIN_PX: float = 24.0
+
+var _bg: ColorRect
+
+
+func _ready() -> void:
+	mouse_filter = Control.MOUSE_FILTER_STOP
+	custom_minimum_size = Vector2(SIZE_PX, SIZE_PX)
+	anchor_left = 1.0
+	anchor_top = 1.0
+	anchor_right = 1.0
+	anchor_bottom = 1.0
+	offset_left = -SIZE_PX - MARGIN_PX
+	offset_top = -SIZE_PX - MARGIN_PX
+	offset_right = -MARGIN_PX
+	offset_bottom = -MARGIN_PX
+	_bg = ColorRect.new()
+	_bg.color = Color(1.0, 0.3, 0.3, 0.35)
+	_bg.anchor_right = 1.0
+	_bg.anchor_bottom = 1.0
+	_bg.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	add_child(_bg)
+	var label := Label.new()
+	label.text = "FIRE"
+	label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	label.anchor_right = 1.0
+	label.anchor_bottom = 1.0
+	label.add_theme_font_size_override("font_size", 18)
+	label.add_theme_color_override("font_color", Color(1, 1, 1, 0.9))
+	label.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	add_child(label)
+
+
+func _gui_input(event: InputEvent) -> void:
+	if event is InputEventScreenTouch:
+		var t: InputEventScreenTouch = event
+		if t.pressed:
+			fire_requested.emit()
+			accept_event()
+	elif event is InputEventMouseButton:
+		var m: InputEventMouseButton = event
+		if m.pressed and m.button_index == MOUSE_BUTTON_LEFT:
+			fire_requested.emit()
+			accept_event()

--- a/godot/scenes/invaders/view/fire_button.gd.uid
+++ b/godot/scenes/invaders/view/fire_button.gd.uid
@@ -1,0 +1,1 @@
+uid://cs6iq55gg5cej

--- a/godot/scenes/invaders/view/formation_layer.gd
+++ b/godot/scenes/invaders/view/formation_layer.gd
@@ -1,0 +1,74 @@
+extends Node2D
+## Formation renderer. Draws one rect per live enemy plus a per-row "march pose"
+## glyph that toggles each formation step (visible "wobble"). Per-cell draw mode
+## is just an int 0/1 selecting between two hand-coded shape variants.
+##
+## Redrawn on:
+##  - formation_origin change (formation step)
+##  - enemy_mask change (enemy killed)
+## Pure renderer: pulls everything from the snapshot the parent passes in.
+
+const InvadersConfig := preload("res://scripts/invaders/core/invaders_config.gd")
+const InvadersLevel := preload("res://scripts/invaders/core/invaders_level.gd")
+const Palette := preload("res://scripts/invaders/invaders_palette.gd")
+
+var _cfg: InvadersConfig
+var _level: InvadersLevel
+var _snap: Dictionary = {}
+var _pose: int = Palette.MARCH_POSE_A
+
+
+func configure(cfg: InvadersConfig, lvl: InvadersLevel) -> void:
+	_cfg = cfg
+	_level = lvl
+	queue_redraw()
+
+
+func update_from_snapshot(snap: Dictionary, pose: int) -> void:
+	_snap = snap
+	_pose = pose
+	queue_redraw()
+
+
+## Test accessor — current march pose. Exposed for the scene test that asserts
+## the pose alternates across two consecutive formation steps.
+func march_pose() -> int:
+	return _pose
+
+
+func _draw() -> void:
+	if _cfg == null or _snap.is_empty():
+		return
+	var fm: Dictionary = _snap.get("formation", {})
+	var ox: float = float(fm.get("ox", 0.0))
+	var oy: float = float(fm.get("oy", 0.0))
+	var live: PackedByteArray = _snap.get("enemies", PackedByteArray())
+	var rows: int = _cfg.rows
+	var cols: int = _cfg.cols
+	if live.size() < rows * cols:
+		return
+	var hx: float = _cfg.enemy_hx
+	var hy: float = _cfg.enemy_hy
+	for r in range(rows):
+		var color: Color = Palette.row_color(r)
+		for c in range(cols):
+			if live[r * cols + c] != 1:
+				continue
+			var cx: float = ox + c * _cfg.cell_w + _cfg.cell_w * 0.5
+			var cy: float = oy + r * _cfg.cell_h + _cfg.cell_h * 0.5
+			_draw_enemy(cx, cy, hx, hy, color, _pose)
+
+
+func _draw_enemy(cx: float, cy: float, hx: float, hy: float, color: Color, pose: int) -> void:
+	# Body: solid rect with a 1-px notch on alternating poses for the "wobble".
+	var body := Rect2(Vector2(cx - hx, cy - hy), Vector2(hx * 2.0, hy * 2.0))
+	draw_rect(body, color, true)
+	# Tiny "legs" rectangle: pose A draws legs at corners, pose B in the middle.
+	var leg_w: float = 1.0
+	var leg_h: float = 1.5
+	var ly: float = cy + hy
+	if pose == Palette.MARCH_POSE_A:
+		draw_rect(Rect2(Vector2(cx - hx, ly), Vector2(leg_w, leg_h)), color, true)
+		draw_rect(Rect2(Vector2(cx + hx - leg_w, ly), Vector2(leg_w, leg_h)), color, true)
+	else:
+		draw_rect(Rect2(Vector2(cx - leg_w * 0.5, ly), Vector2(leg_w, leg_h)), color, true)

--- a/godot/scenes/invaders/view/formation_layer.gd.uid
+++ b/godot/scenes/invaders/view/formation_layer.gd.uid
@@ -1,0 +1,1 @@
+uid://dt7haosngxy5h

--- a/godot/scenes/invaders/view/game_over_overlay.gd
+++ b/godot/scenes/invaders/view/game_over_overlay.gd
@@ -1,0 +1,64 @@
+extends CanvasLayer
+## Game-over overlay. Layer 10. ui_accept retries; ui_cancel returns to menu.
+## Shows final score + wave reached.
+
+signal restart_requested()
+signal menu_requested()
+
+var _score_label: Label
+var _wave_label: Label
+var _menu_btn: Button
+
+
+func _ready() -> void:
+	layer = 10
+	var bg := ColorRect.new()
+	bg.color = Color(0, 0, 0, 0.7)
+	bg.anchor_right = 1.0
+	bg.anchor_bottom = 1.0
+	add_child(bg)
+	var vbox := VBoxContainer.new()
+	vbox.alignment = BoxContainer.ALIGNMENT_CENTER
+	vbox.anchor_right = 1.0
+	vbox.anchor_bottom = 1.0
+	vbox.add_theme_constant_override("separation", 16)
+	add_child(vbox)
+	var title := Label.new()
+	title.text = "GAME OVER"
+	title.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	title.add_theme_font_size_override("font_size", 48)
+	vbox.add_child(title)
+	_score_label = Label.new()
+	_score_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	_score_label.add_theme_font_size_override("font_size", 24)
+	vbox.add_child(_score_label)
+	_wave_label = Label.new()
+	_wave_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	_wave_label.add_theme_font_size_override("font_size", 18)
+	vbox.add_child(_wave_label)
+	var hint := Label.new()
+	hint.text = "Press Confirm to retry / Cancel to exit"
+	hint.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	hint.add_theme_font_size_override("font_size", 16)
+	vbox.add_child(hint)
+	_menu_btn = Button.new()
+	_menu_btn.text = "Back to menu"
+	_menu_btn.pressed.connect(func() -> void: menu_requested.emit())
+	vbox.add_child(_menu_btn)
+	InputManager.action_pressed.connect(_on_action_pressed)
+	visible = false
+
+
+func show_with(score: int, wave: int) -> void:
+	_score_label.text = "Final Score: %d" % score
+	_wave_label.text = "Wave reached: %d" % wave
+	visible = true
+
+
+func _on_action_pressed(action: StringName) -> void:
+	if not visible:
+		return
+	if action == &"ui_accept" or action == &"fire":
+		restart_requested.emit()
+	elif action == &"ui_cancel":
+		menu_requested.emit()

--- a/godot/scenes/invaders/view/game_over_overlay.gd.uid
+++ b/godot/scenes/invaders/view/game_over_overlay.gd.uid
@@ -1,0 +1,1 @@
+uid://bo6tv6578np6p

--- a/godot/scenes/invaders/view/hud.gd
+++ b/godot/scenes/invaders/view/hud.gd
@@ -1,0 +1,63 @@
+extends Control
+## Invaders HUD: score (top-left), wave (top-center), lives as small ship icons
+## (top-right). Updated by parent on every visible state change.
+
+const InvadersConfig := preload("res://scripts/invaders/core/invaders_config.gd")
+const Palette := preload("res://scripts/invaders/invaders_palette.gd")
+
+var _cfg: InvadersConfig
+var _score_label: Label
+var _wave_label: Label
+var _lives_box: HBoxContainer
+var _last_lives: int = -1
+
+
+func _ready() -> void:
+	anchor_right = 1.0
+	anchor_bottom = 0.0
+	offset_bottom = 56.0
+	mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_score_label = Label.new()
+	_score_label.text = "Score: 0"
+	_score_label.add_theme_font_size_override("font_size", 22)
+	_score_label.add_theme_color_override("font_color", Palette.HUD_TEXT)
+	_score_label.position = Vector2(16, 12)
+	add_child(_score_label)
+	_wave_label = Label.new()
+	_wave_label.text = "Wave 1"
+	_wave_label.add_theme_font_size_override("font_size", 22)
+	_wave_label.add_theme_color_override("font_color", Palette.HUD_TEXT)
+	_wave_label.anchor_left = 0.5
+	_wave_label.anchor_right = 0.5
+	_wave_label.position = Vector2(-40, 12)
+	add_child(_wave_label)
+	_lives_box = HBoxContainer.new()
+	_lives_box.anchor_left = 1.0
+	_lives_box.anchor_right = 1.0
+	_lives_box.position = Vector2(-120, 12)
+	_lives_box.add_theme_constant_override("separation", 4)
+	add_child(_lives_box)
+
+
+func configure(cfg: InvadersConfig) -> void:
+	_cfg = cfg
+
+
+func update_from_snapshot(snap: Dictionary) -> void:
+	_score_label.text = "Score: %d" % int(snap.get("score", 0))
+	_wave_label.text = "Wave %d" % int(snap.get("wave", 1))
+	var lives: int = int(snap.get("lives", 0))
+	if lives != _last_lives:
+		_rebuild_lives_icons(lives)
+		_last_lives = lives
+
+
+func _rebuild_lives_icons(count: int) -> void:
+	for child in _lives_box.get_children():
+		_lives_box.remove_child(child)
+		child.queue_free()
+	for i in range(count):
+		var r := ColorRect.new()
+		r.color = Palette.PLAYER
+		r.custom_minimum_size = Vector2(20, 10)
+		_lives_box.add_child(r)

--- a/godot/scenes/invaders/view/hud.gd.uid
+++ b/godot/scenes/invaders/view/hud.gd.uid
@@ -1,0 +1,1 @@
+uid://bied8ll1q0lxd

--- a/godot/scenes/invaders/view/pause_overlay.gd
+++ b/godot/scenes/invaders/view/pause_overlay.gd
@@ -1,0 +1,49 @@
+extends CanvasLayer
+## Pause overlay for invaders. Layer 10. Mirrors breakout/snake pattern.
+
+signal menu_requested()
+
+var _menu_btn: Button
+
+
+func _ready() -> void:
+	layer = 10
+	var bg := ColorRect.new()
+	bg.color = Color(0, 0, 0, 0.6)
+	bg.anchor_right = 1.0
+	bg.anchor_bottom = 1.0
+	add_child(bg)
+	var vbox := VBoxContainer.new()
+	vbox.alignment = BoxContainer.ALIGNMENT_CENTER
+	vbox.anchor_right = 1.0
+	vbox.anchor_bottom = 1.0
+	vbox.add_theme_constant_override("separation", 16)
+	add_child(vbox)
+	var label := Label.new()
+	label.text = "PAUSED"
+	label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	label.add_theme_font_size_override("font_size", 36)
+	vbox.add_child(label)
+	var hint := Label.new()
+	hint.text = "Press Pause to resume"
+	hint.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	hint.add_theme_font_size_override("font_size", 18)
+	vbox.add_child(hint)
+	_menu_btn = Button.new()
+	_menu_btn.text = "Back to menu"
+	_menu_btn.pressed.connect(func() -> void: menu_requested.emit())
+	vbox.add_child(_menu_btn)
+	visibility_changed.connect(_on_visibility_changed)
+	InputManager.action_pressed.connect(_on_action_pressed)
+
+
+func _on_visibility_changed() -> void:
+	if visible and is_instance_valid(_menu_btn):
+		_menu_btn.grab_focus()
+
+
+func _on_action_pressed(action: StringName) -> void:
+	if not visible:
+		return
+	if action == &"ui_cancel":
+		menu_requested.emit()

--- a/godot/scenes/invaders/view/pause_overlay.gd.uid
+++ b/godot/scenes/invaders/view/pause_overlay.gd.uid
@@ -1,0 +1,1 @@
+uid://cd1xv8k1helhs

--- a/godot/scenes/invaders/view/player_layer.gd
+++ b/godot/scenes/invaders/view/player_layer.gd
@@ -1,0 +1,50 @@
+extends Node2D
+## Player ship renderer. Blocky rect with a small triangular top. Modulates
+## alpha when the player is invulnerable (recently hit) for a visible flash.
+
+const InvadersConfig := preload("res://scripts/invaders/core/invaders_config.gd")
+const Palette := preload("res://scripts/invaders/invaders_palette.gd")
+
+const FLASH_PERIOD_MS: int = 120
+
+var _cfg: InvadersConfig
+var _snap: Dictionary = {}
+
+
+func configure(cfg: InvadersConfig) -> void:
+	_cfg = cfg
+	queue_redraw()
+
+
+func update_from_snapshot(snap: Dictionary) -> void:
+	_snap = snap
+	queue_redraw()
+
+
+func _draw() -> void:
+	if _cfg == null or _snap.is_empty():
+		return
+	var p: Dictionary = _snap.get("player", {})
+	if not bool(p.get("alive", false)):
+		return
+	var x: float = float(p.get("x", _cfg.world_w * 0.5))
+	var y: float = _cfg.player_y
+	var hw: float = _cfg.player_w * 0.5
+	var hh: float = _cfg.player_h * 0.5
+	var color: Color = Palette.PLAYER
+	# Invulnerability flash: blink alpha based on remaining ms.
+	var iu: int = int(p.get("invuln_until_ms", 0))
+	if iu > 0:
+		var on: bool = (iu / FLASH_PERIOD_MS) % 2 == 0
+		if not on:
+			color = Color(color.r, color.g, color.b, 0.35)
+	# Body.
+	draw_rect(Rect2(Vector2(x - hw, y - hh * 0.5), Vector2(hw * 2.0, hh)), color, true)
+	# Triangular cannon top.
+	var top := PackedVector2Array([
+		Vector2(x - 1.0, y - hh * 0.5),
+		Vector2(x + 1.0, y - hh * 0.5),
+		Vector2(x + 1.0, y - hh),
+		Vector2(x - 1.0, y - hh),
+	])
+	draw_polygon(top, PackedColorArray([color, color, color, color]))

--- a/godot/scenes/invaders/view/player_layer.gd.uid
+++ b/godot/scenes/invaders/view/player_layer.gd.uid
@@ -1,0 +1,1 @@
+uid://78wehbnijokm

--- a/godot/scenes/invaders/view/ufo_layer.gd
+++ b/godot/scenes/invaders/view/ufo_layer.gd
@@ -1,0 +1,68 @@
+extends Node2D
+## UFO renderer + transient score popup. The popup is a scene-only artifact
+## derived from snapshot diff (UFO disappeared + score increased on the same
+## tick). It fades in/out at the UFO's last position.
+
+const InvadersConfig := preload("res://scripts/invaders/core/invaders_config.gd")
+const Palette := preload("res://scripts/invaders/invaders_palette.gd")
+
+const POPUP_DURATION_MS: int = 600
+
+var _cfg: InvadersConfig
+var _snap: Dictionary = {}
+
+# Active score popups: Array of {x, y, value, t0_ms}.
+var _popups: Array = []
+
+
+func configure(cfg: InvadersConfig) -> void:
+	_cfg = cfg
+	set_process(true)
+	queue_redraw()
+
+
+func update_from_snapshot(snap: Dictionary) -> void:
+	_snap = snap
+	queue_redraw()
+
+
+func spawn_score_popup(world_x: float, value: int) -> void:
+	_popups.append({"x": world_x, "y": _cfg.ufo_y, "value": value, "t0_ms": Time.get_ticks_msec()})
+	queue_redraw()
+
+
+func _process(_delta: float) -> void:
+	if _popups.is_empty():
+		return
+	var now: int = Time.get_ticks_msec()
+	var i: int = 0
+	while i < _popups.size():
+		var p: Dictionary = _popups[i]
+		if now - int(p["t0_ms"]) > POPUP_DURATION_MS:
+			_popups.remove_at(i)
+		else:
+			i += 1
+	queue_redraw()
+
+
+func _draw() -> void:
+	if _cfg == null:
+		return
+	var ufo: Variant = _snap.get("ufo", null)
+	if ufo is Dictionary:
+		var x: float = float((ufo as Dictionary).get("x", 0.0))
+		var y: float = _cfg.ufo_y
+		var hw: float = _cfg.ufo_w * 0.5
+		var hh: float = _cfg.ufo_h * 0.5
+		draw_rect(Rect2(Vector2(x - hw, y - hh * 0.6), Vector2(hw * 2.0, hh * 1.2)), Palette.UFO, true)
+		# Dome cap.
+		draw_rect(Rect2(Vector2(x - hw * 0.5, y - hh), Vector2(hw, hh * 0.5)), Palette.UFO, true)
+	var now: int = Time.get_ticks_msec()
+	for p in _popups:
+		var t: float = clampf(float(now - int(p["t0_ms"])) / float(POPUP_DURATION_MS), 0.0, 1.0)
+		var alpha: float = 1.0 - t
+		var px: float = float(p["x"])
+		var py: float = float(p["y"]) - t * 6.0
+		var color := Color(Palette.SCORE_POPUP.r, Palette.SCORE_POPUP.g, Palette.SCORE_POPUP.b, alpha)
+		var font := ThemeDB.fallback_font
+		draw_string(font, Vector2(px, py), str(int(p["value"])), HORIZONTAL_ALIGNMENT_CENTER, -1.0, 8, color)

--- a/godot/scenes/invaders/view/ufo_layer.gd.uid
+++ b/godot/scenes/invaders/view/ufo_layer.gd.uid
@@ -1,0 +1,1 @@
+uid://ddvdxtq5jkt2i

--- a/godot/scenes/invaders/view/wave_interlude.gd
+++ b/godot/scenes/invaders/view/wave_interlude.gd
@@ -1,0 +1,29 @@
+extends CanvasLayer
+## Wave-cleared interlude. Layer 5 (above world, below pause overlay). Shows a
+## brief "WAVE N" banner; the parent times its dismissal in real time and
+## ensures `state.tick()` is not called while we're visible.
+
+var _label: Label
+
+
+func _ready() -> void:
+	layer = 5
+	var bg := ColorRect.new()
+	bg.color = Color(0, 0, 0, 0.5)
+	bg.anchor_right = 1.0
+	bg.anchor_bottom = 1.0
+	add_child(bg)
+	_label = Label.new()
+	_label.text = "WAVE 2"
+	_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	_label.anchor_right = 1.0
+	_label.anchor_bottom = 1.0
+	_label.add_theme_font_size_override("font_size", 64)
+	add_child(_label)
+	visible = false
+
+
+func show_with(wave: int) -> void:
+	_label.text = "WAVE %d" % wave
+	visible = true

--- a/godot/scenes/invaders/view/wave_interlude.gd.uid
+++ b/godot/scenes/invaders/view/wave_interlude.gd.uid
@@ -1,0 +1,1 @@
+uid://6vdmbdm1m24o

--- a/godot/scripts/core/game/game_registry.gd
+++ b/godot/scripts/core/game/game_registry.gd
@@ -13,6 +13,7 @@ const _GAMES: Array = [
 	[&"snake", "Snake", "res://scenes/snake/snake.tscn", ""],
 	[&"g2048", "2048", "res://scenes/g2048/g2048.tscn", ""],
 	[&"breakout", "Breakout", "res://scenes/breakout/breakout.tscn", ""],
+	[&"invaders", "Invaders", "res://scenes/invaders/invaders.tscn", ""],
 ]
 
 static func all() -> Array:

--- a/godot/scripts/core/input/action_map_defaults.gd
+++ b/godot/scripts/core/input/action_map_defaults.gd
@@ -4,7 +4,7 @@ extends Object
 
 const ACTIONS: Array[StringName] = [
 	&"move_left", &"move_right", &"move_up", &"move_down",
-	&"soft_drop", &"hard_drop",
+	&"soft_drop", &"hard_drop", &"fire",
 	&"rotate_cw", &"rotate_ccw", &"hold", &"undo", &"pause",
 	&"ui_accept", &"ui_cancel",
 ]
@@ -24,6 +24,7 @@ const _DEFAULTS: Dictionary = {
 	&"move_down":  [["kbd", KEY_DOWN], ["kbd", KEY_S],     ["pad", JOY_BUTTON_DPAD_DOWN]],
 	&"soft_drop":  [["kbd", KEY_DOWN], ["kbd", KEY_S],     ["pad", JOY_BUTTON_DPAD_DOWN]],
 	&"hard_drop":  [["kbd", KEY_SPACE],                    ["pad", JOY_BUTTON_A]],
+	&"fire":       [["kbd", KEY_SPACE], ["kbd", KEY_J],    ["pad", JOY_BUTTON_A]],
 	&"rotate_cw":  [["kbd", KEY_UP], ["kbd", KEY_X],       ["pad", JOY_BUTTON_B]],
 	&"rotate_ccw": [["kbd", KEY_Z],                        ["pad", JOY_BUTTON_X]],
 	&"hold":       [["kbd", KEY_C], ["kbd", KEY_SHIFT],    ["pad", JOY_BUTTON_Y], ["pad", JOY_BUTTON_LEFT_SHOULDER]],

--- a/godot/scripts/invaders/core/aabb.gd.uid
+++ b/godot/scripts/invaders/core/aabb.gd.uid
@@ -1,0 +1,1 @@
+uid://dlfrponhw7bjy

--- a/godot/scripts/invaders/core/bunker_erosion.gd.uid
+++ b/godot/scripts/invaders/core/bunker_erosion.gd.uid
@@ -1,0 +1,1 @@
+uid://dmwtdjull0vlh

--- a/godot/scripts/invaders/core/bunker_grid.gd.uid
+++ b/godot/scripts/invaders/core/bunker_grid.gd.uid
@@ -1,0 +1,1 @@
+uid://b6lpmyupnh76q

--- a/godot/scripts/invaders/core/formation.gd.uid
+++ b/godot/scripts/invaders/core/formation.gd.uid
@@ -1,0 +1,1 @@
+uid://bggdkreilpj2u

--- a/godot/scripts/invaders/core/invaders_config.gd.uid
+++ b/godot/scripts/invaders/core/invaders_config.gd.uid
@@ -1,0 +1,1 @@
+uid://chtegvsxgptea

--- a/godot/scripts/invaders/core/invaders_level.gd.uid
+++ b/godot/scripts/invaders/core/invaders_level.gd.uid
@@ -1,0 +1,1 @@
+uid://bvcaxbspjcluf

--- a/godot/scripts/invaders/core/invaders_state.gd.uid
+++ b/godot/scripts/invaders/core/invaders_state.gd.uid
@@ -1,0 +1,1 @@
+uid://dsebdutpom681

--- a/godot/scripts/invaders/core/ufo.gd.uid
+++ b/godot/scripts/invaders/core/ufo.gd.uid
@@ -1,0 +1,1 @@
+uid://dxi0x2aolmg6d

--- a/godot/scripts/invaders/invaders_palette.gd
+++ b/godot/scripts/invaders/invaders_palette.gd
@@ -1,0 +1,47 @@
+extends Object
+## Palette + draw constants for the Invaders scene. No Image/ImageTexture —
+## all visuals are `_draw` calls keyed off these constants.
+
+# Background, bunker, player, bullets, UFO, HUD text.
+const BG: Color = Color(0.02, 0.02, 0.05, 1.0)
+const PLAYER: Color = Color(0.30, 0.95, 0.40)         # classic green
+const PLAYER_BULLET: Color = Color(1.00, 1.00, 1.00)
+const BUNKER: Color = Color(0.30, 0.95, 0.40)
+const UFO: Color = Color(0.95, 0.30, 0.40)            # red saucer
+const HUD_TEXT: Color = Color(1.00, 1.00, 1.00)
+const SCORE_POPUP: Color = Color(1.00, 0.85, 0.20)
+const EXPLOSION: Color = Color(1.00, 0.65, 0.10)
+
+# Per-row colors for the formation. Indexed by row (0 = top).
+# Five-row default formation: top is purple, mid bands cyan, bottom-most yellow.
+const ROW_COLORS: Array[Color] = [
+	Color(0.85, 0.40, 0.95),    # row 0 (octopus / 30 pts)
+	Color(0.30, 0.85, 0.95),    # row 1 (crab / 20 pts)
+	Color(0.30, 0.85, 0.95),    # row 2 (crab / 20 pts)
+	Color(0.95, 0.95, 0.30),    # row 3 (squid / 10 pts)
+	Color(0.95, 0.95, 0.30),    # row 4 (squid / 10 pts)
+]
+
+# Three-color palette for enemy bullets, picked by index for visual variety.
+const ENEMY_BULLET_COLORS: Array[Color] = [
+	Color(1.00, 1.00, 1.00),
+	Color(1.00, 0.85, 0.20),
+	Color(0.85, 0.40, 0.95),
+]
+
+# March-pose toggle. The formation_layer flips between these two on every
+# formation step; each pose is a distinct hand-coded glyph in `_draw`.
+const MARCH_POSE_A: int = 0
+const MARCH_POSE_B: int = 1
+
+
+static func row_color(row_idx: int) -> Color:
+	if row_idx < 0 or row_idx >= ROW_COLORS.size():
+		return Color(0.6, 0.6, 0.6, 1.0)
+	return ROW_COLORS[row_idx]
+
+
+static func enemy_bullet_color(bullet_idx: int) -> Color:
+	if bullet_idx < 0:
+		return ENEMY_BULLET_COLORS[0]
+	return ENEMY_BULLET_COLORS[bullet_idx % ENEMY_BULLET_COLORS.size()]

--- a/godot/scripts/invaders/invaders_palette.gd.uid
+++ b/godot/scripts/invaders/invaders_palette.gd.uid
@@ -1,0 +1,1 @@
+uid://ya37di2wvbe4

--- a/godot/tests/integration/test_invaders_scene.gd
+++ b/godot/tests/integration/test_invaders_scene.gd
@@ -1,0 +1,200 @@
+extends GutTest
+## Scene-level integration test for invaders. Drives the scene via Input
+## actions so InputManager's real path runs. Mirrors test_breakout_scene
+## structure.
+##
+## Determinism: scene.start(SEED) replaces InvadersGameState with a fresh,
+## seeded one in before_each.
+
+const ActionMapDefaults := preload("res://scripts/core/input/action_map_defaults.gd")
+const InvadersGameState := preload("res://scripts/invaders/core/invaders_state.gd")
+const Palette := preload("res://scripts/invaders/invaders_palette.gd")
+
+const SEED: int = 12345
+
+var scene: Control
+
+
+func before_each() -> void:
+	for action in ActionMapDefaults.ACTIONS:
+		Input.action_release(action)
+	await get_tree().process_frame
+	await get_tree().process_frame
+	var packed: PackedScene = load("res://scenes/invaders/invaders.tscn")
+	scene = packed.instantiate()
+	add_child(scene)
+	await get_tree().process_frame
+	scene.start(SEED)
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+
+func after_each() -> void:
+	for action in ActionMapDefaults.ACTIONS:
+		Input.action_release(action)
+	if is_instance_valid(scene):
+		scene.queue_free()
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+
+func _press_release(action: StringName) -> void:
+	Input.action_press(action)
+	await get_tree().process_frame
+	await get_tree().process_frame
+	Input.action_release(action)
+	await get_tree().process_frame
+
+
+# --- Tests ---
+
+
+func test_starts_with_full_formation_and_lives() -> void:
+	var snap: Dictionary = scene.state.snapshot()
+	assert_eq(int(snap.get("wave", -1)), 1, "starts at wave 1")
+	assert_eq(int(snap.get("lives", -1)), scene.config.lives_start,
+		"starts with lives_start lives")
+	assert_eq(int(snap.get("score", -1)), 0, "starts with zero score")
+	# Every cell alive.
+	var alive: PackedByteArray = snap.get("enemies", PackedByteArray())
+	assert_eq(alive.size(), scene.config.rows * scene.config.cols,
+		"enemies grid sized rows*cols")
+	var live_count: int = 0
+	for i in range(alive.size()):
+		if alive[i] == 1:
+			live_count += 1
+	assert_eq(live_count, scene.config.rows * scene.config.cols,
+		"every enemy alive at start")
+
+
+func test_move_right_drives_player() -> void:
+	# Acceptance #2: player responds within one frame.
+	var initial_x: float = scene.state.player_x
+	Input.action_press(&"move_right")
+	for _i in 4:
+		await get_tree().process_frame
+	Input.action_release(&"move_right")
+	assert_gt(scene.state.player_x, initial_x,
+		"player x increased after holding move_right")
+
+
+func test_fire_action_spawns_player_bullet() -> void:
+	# Acceptance #3: fire triggers state.fire(); a second press is a no-op.
+	assert_false(scene.state.player_bullet_alive, "no bullet at start")
+	await _press_release(&"fire")
+	# One process frame for InputManager → scene → state.fire().
+	await get_tree().process_frame
+	assert_true(scene.state.player_bullet_alive,
+		"player bullet spawned after fire press")
+	# Fire again — bullet count must not increase (scene-level no-op).
+	await _press_release(&"fire")
+	await get_tree().process_frame
+	# Still exactly one player bullet (it's a single-bullet rule in core).
+	assert_true(scene.state.player_bullet_alive)
+
+
+func test_pause_blocks_player_motion() -> void:
+	await _press_release(&"pause")
+	assert_true(scene.pause_overlay.visible, "pause overlay visible after pause")
+	var x_at_pause: float = scene.state.player_x
+	Input.action_press(&"move_right")
+	for _i in 5:
+		await get_tree().process_frame
+	Input.action_release(&"move_right")
+	assert_almost_eq(scene.state.player_x, x_at_pause, 0.01,
+		"player x did not change while paused")
+	# Resume.
+	await _press_release(&"pause")
+	assert_false(scene.pause_overlay.visible, "pause overlay hidden after resume")
+
+
+func test_pause_blocks_state_tick() -> void:
+	# Acceptance #5 spirit: while overlay is up, state.tick() returns false.
+	await _press_release(&"pause")
+	var snap_before: Dictionary = scene.state.snapshot()
+	for _i in 5:
+		await get_tree().process_frame
+	var snap_after: Dictionary = scene.state.snapshot()
+	# Formation origin must not move while paused.
+	assert_eq(
+		(snap_before.get("formation", {}) as Dictionary).get("ox", 0.0),
+		(snap_after.get("formation", {}) as Dictionary).get("ox", 0.0),
+		"formation ox unchanged while paused"
+	)
+
+
+func test_wave_interlude_blocks_ticks() -> void:
+	# Acceptance #5: scene must NOT call state.tick() during the 1.2 s
+	# interlude. Force a wave change by clearing the formation directly.
+	for i in range(scene.state.live_mask.size()):
+		scene.state.live_mask[i] = 0
+	# Trigger one tick so core advances to the wave change. After this,
+	# wave should increment and the scene should latch INTERLUDE phase.
+	await get_tree().process_frame
+	await get_tree().process_frame
+	await get_tree().process_frame
+	# The scene-side phase becomes INTERLUDE on the very tick where wave
+	# changed. State now has a fresh full formation again.
+	assert_eq(scene._phase, scene.Phase.INTERLUDE,
+		"scene latches INTERLUDE phase on wave change")
+	assert_true(scene.wave_interlude.visible, "wave interlude visible")
+	# During the interlude the formation origin must not move.
+	var fm0: Dictionary = scene.state.snapshot().get("formation", {})
+	var ox0: float = fm0.get("ox", 0.0)
+	for _i in 6:
+		await get_tree().process_frame
+	# Interlude lasts 1.2 s; six frames at ~16 ms is well inside it.
+	var fm1: Dictionary = scene.state.snapshot().get("formation", {})
+	assert_eq(fm1.get("ox", 0.0), ox0,
+		"formation origin frozen during interlude")
+
+
+func test_formation_march_pose_alternates() -> void:
+	# Acceptance #9: per-cell draw mode toggles between two values across
+	# two consecutive formation steps.
+	var snap0: Dictionary = scene.state.snapshot()
+	var ox0: float = (snap0.get("formation", {}) as Dictionary).get("ox", 0.0)
+	# Step the formation directly to avoid waiting on cadence.
+	scene.state._step_formation()
+	scene._update_views()
+	var pose1: int = scene.formation_layer.march_pose()
+	scene.state._step_formation()
+	scene._update_views()
+	var pose2: int = scene.formation_layer.march_pose()
+	assert_ne(pose1, pose2, "march pose alternates across consecutive steps")
+
+
+func test_game_over_overlay_when_lives_zero() -> void:
+	# Acceptance #7: game over reachable via lives = 0.
+	scene.state.lives = 0
+	scene.state.player_alive = false
+	for _i in 5:
+		await get_tree().process_frame
+	assert_true(scene.game_over_overlay.visible,
+		"game over overlay visible when lives = 0")
+
+
+func test_restart_after_game_over_resets_to_wave_1() -> void:
+	# Acceptance #7: confirm restarts at wave 1 with a fresh seed.
+	scene.state.lives = 0
+	scene.state.player_alive = false
+	for _i in 5:
+		await get_tree().process_frame
+	assert_true(scene.game_over_overlay.visible)
+	scene._on_restart_pressed()
+	await get_tree().process_frame
+	await get_tree().process_frame
+	assert_eq(scene.state.wave, 1, "restart returns to wave 1")
+	assert_eq(scene.state.lives, scene.config.lives_start,
+		"restart restores full lives")
+	assert_false(scene.game_over_overlay.visible,
+		"game over overlay hidden after restart")
+
+
+func test_teardown_releases_signal_connection() -> void:
+	# Acceptance #1 spirit: teardown disconnects from InputManager.
+	assert_true(InputManager.action_pressed.is_connected(scene._on_action_pressed),
+		"connected before teardown")
+	scene.teardown()
+	assert_false(InputManager.action_pressed.is_connected(scene._on_action_pressed),
+		"disconnected after teardown")

--- a/godot/tests/integration/test_invaders_scene.gd.uid
+++ b/godot/tests/integration/test_invaders_scene.gd.uid
@@ -1,0 +1,1 @@
+uid://bbywucccxj70s

--- a/godot/tests/integration/test_invaders_session.gd
+++ b/godot/tests/integration/test_invaders_session.gd
@@ -1,0 +1,113 @@
+extends GutTest
+## Integration test: scripted player-intent log against InvadersGameState
+## with a fixed seed → asserts deterministic snapshot stream from core.
+## Pure-core (no scene); the scene test covers wiring.
+
+const InvadersConfig := preload("res://scripts/invaders/core/invaders_config.gd")
+const InvadersLevel := preload("res://scripts/invaders/core/invaders_level.gd")
+const InvadersGameState := preload("res://scripts/invaders/core/invaders_state.gd")
+
+const SEED_A: int = 0xA1
+const SEED_B: int = 0xB2
+
+
+func _make_state(seed_value: int) -> InvadersGameState:
+	var cfg: InvadersConfig = InvadersConfig.new()
+	var lvl: InvadersLevel = InvadersLevel.new()
+	return InvadersGameState.create(seed_value, cfg, lvl)
+
+
+func test_same_seed_same_snapshot_stream() -> void:
+	# Same seed + same input log = identical snapshots at each tick.
+	var s1: InvadersGameState = _make_state(SEED_A)
+	var s2: InvadersGameState = _make_state(SEED_A)
+	var t: int = 0
+	for i in range(120):
+		t += 16
+		s1.set_player_intent(0.0)
+		s2.set_player_intent(0.0)
+		s1.tick(t)
+		s2.tick(t)
+	var sn1: Dictionary = s1.snapshot()
+	var sn2: Dictionary = s2.snapshot()
+	assert_eq(sn1["score"], sn2["score"])
+	assert_eq(sn1["wave"], sn2["wave"])
+	assert_eq(sn1["lives"], sn2["lives"])
+	assert_eq(sn1["formation"]["ox"], sn2["formation"]["ox"])
+	assert_eq(sn1["formation"]["oy"], sn2["formation"]["oy"])
+	# Compare PackedByteArray contents element-wise.
+	var e1: PackedByteArray = sn1["enemies"]
+	var e2: PackedByteArray = sn2["enemies"]
+	assert_eq(e1.size(), e2.size())
+	for i in range(e1.size()):
+		assert_eq(e1[i], e2[i])
+
+
+func test_different_seed_diverges() -> void:
+	# Distinct seeds eventually produce a different state — at minimum, the
+	# UFO RNG diverges, so over many ticks at least one snapshot field
+	# differs. We just assert the snapshots aren't trivially identical.
+	var s1: InvadersGameState = _make_state(SEED_A)
+	var s2: InvadersGameState = _make_state(SEED_B)
+	var t: int = 0
+	for i in range(2000):
+		t += 16
+		s1.tick(t)
+		s2.tick(t)
+	var sn1: Dictionary = s1.snapshot()
+	var sn2: Dictionary = s2.snapshot()
+	# Either RNG state diverged or some derived field did.
+	assert_ne(sn1["rng_bullet"], sn2["rng_bullet"],
+		"bullet RNG state diverges across seeds")
+
+
+func test_fire_intent_log_produces_player_bullet() -> void:
+	# Scripted log: t=100ms fire, expect a bullet to appear and travel up.
+	var s: InvadersGameState = _make_state(SEED_A)
+	s.tick(0)
+	s.tick(50)
+	assert_false(s.player_bullet_alive, "no bullet before fire")
+	var fired: bool = s.fire()
+	assert_true(fired, "fire() returns true on first call")
+	assert_true(s.player_bullet_alive)
+	var fired_again: bool = s.fire()
+	assert_false(fired_again, "second fire() returns false while bullet alive")
+	# Tick forward; bullet y must decrease (travels up).
+	var by0: float = s.player_bullet_y
+	s.tick(150)
+	assert_lt(s.player_bullet_y, by0, "player bullet moves up after tick")
+
+
+func test_set_last_tick_prevents_simulation_burst() -> void:
+	# Simulating a long pause: pre-pause tick at 100ms, then "wake up" at
+	# 5000ms via set_last_tick(5000); the very next tick at 5016ms must
+	# NOT step the formation 4900ms forward.
+	var s: InvadersGameState = _make_state(SEED_A)
+	s.tick(0)
+	s.tick(100)
+	var ox_before: float = s.formation_ox
+	s.set_last_tick(5000)
+	# A very small dt: 16ms. Should at most produce one sub-step worth of motion.
+	s.tick(5016)
+	var dx: float = absf(s.formation_ox - ox_before)
+	# step_dx is config.step_dx (8.0). After only 16 ms there cannot have
+	# been more than zero or one formation steps regardless of cadence.
+	assert_lt(dx, 8.5, "set_last_tick suppressed catch-up auto-step")
+
+
+func test_wave_advances_when_all_enemies_killed() -> void:
+	# Scripted: clear the formation directly, advance one tick, expect wave += 1.
+	var s: InvadersGameState = _make_state(SEED_A)
+	s.tick(0)
+	for i in range(s.live_mask.size()):
+		s.live_mask[i] = 0
+	# tick must process the empty-formation → _advance_wave path.
+	s.tick(16)
+	assert_eq(s.wave, 2, "wave advances when formation cleared")
+	# Live count must be back to full (fresh wave).
+	var live: int = 0
+	for i in range(s.live_mask.size()):
+		if s.live_mask[i] == 1:
+			live += 1
+	assert_eq(live, s.config.rows * s.config.cols,
+		"new wave repopulates the formation")

--- a/godot/tests/integration/test_invaders_session.gd.uid
+++ b/godot/tests/integration/test_invaders_session.gd.uid
@@ -1,0 +1,1 @@
+uid://dr3pbfaxwuot


### PR DESCRIPTION
Closes #28

## How tested
- GUT tests pass locally in worktree (388 tests, +15 new — scene + integration).
- Scene test asserts: full formation on start, move_right drives player, fire spawns one bullet (no double-fire), pause freezes formation ox, wave-cleared interlude blocks ticks for the duration, march pose alternates, game-over → restart loop.
- Integration test asserts: same-seed snapshot stream, different-seed bullet RNG divergence, fire intent log, `set_last_tick` suppresses catch-up auto-step, wave advances on cleared formation.
- Headless `--import` clean; no parse warnings on new scripts.

## Estimated effective diff
1203 lines (total 1527, excluded 324 — tests + .uid auto-files).

⚠️ Exceeds 400 effective lines. Issue must carry the `large-pr-ok` label for auto-merge; otherwise human review will be required. The Dev plan was an 11-commit scene scaffolding pass; tightly bundled because the layers, overlays, and Game-contract wiring all depend on each other and on a single `invaders.tscn`.

## Notes
- `fire` semantic action added to InputManager defaults: Space / J / A button. Same physical inputs as Tetris's `hard_drop` — both are exposed as separate semantic actions; only one is consumed per scene.
- `docs/input-mapping.md` updated with cross-action duplicate-binding allowance and per-game touch-UX-may-differ note.
- Comment posted on #5 (Tetris polish / settings) flagging that the rebind UI must permit cross-action duplicates: lubobill1990/little-games#5 (issuecomment-4366380634).
- All visuals are `_draw` constants in `invaders_palette.gd`; no Image / ImageTexture allocation. Real pixel-art is a follow-up.
- Snapshot-diff drives selective layer redraws; bunkers hashed for cheap diff; UFO score-popup is scene-only (UFO went null + score increased on the same tick).