### PR TITLE
docs(claude): formalize ChangesRequested, skill reviewers/implementers, learning log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,16 @@ Thumbs.db
 # Misc
 *.log
 .tmp/
-# implement-task / gh-pr-review skill scratch
+
+# implement-task / gh-pr-review skill scratch (state files + worktree dirs;
+# these are per-machine and must never land in the repo).
 .lock
+.claude/gh-pr-review-state.json
+.gh-pr-review-state.json
+.pr-review-worktrees/
+.implement-task-state.json
+.implement-task-worktrees/
+.e2e-worktree/
 
 # Audio assets — see godot/assets/audio/README.md and issue #43.
 # Tetris SFX/BGM are licensed for personal/local use only and must never be

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,33 +63,40 @@ CI must be green before merge. Same command runs there.
 ```mermaid
 flowchart LR
     Backlog["Backlog<br/>(idea)"]
-    Ready["Ready<br/>(PRD + Dev plan written,<br/>sub-agent reviewed,<br/>refinements folded in)"]
+    Ready["Ready<br/>(PRD + Dev plan written<br/>and unambiguous)"]
     InProgress["In progress<br/>(branch + impl)"]
     InReview["In review<br/>(PR open, CI green)"]
+    ChangesRequested["Changes requested<br/>(reviewer asked for fixes,<br/>author iterating)"]
     Done["Done<br/>(merged on main)"]
 
-    Backlog -->|Claude writes PRD + Dev plan,<br/>then sub-agent review,<br/>then refines| Ready
+    Backlog -->|Claude writes PRD + Dev plan;<br/>sub-agent review optional<br/>(use for complex/uncertain scope)| Ready
     Ready -->|Claude opens branch, codes| InProgress
     InProgress -->|Claude opens PR| InReview
-    InReview -->|human approves & merges| Done
-    InReview -.->|review requests changes| InProgress
+    InReview -->|reviewer (human or skill) approves & merges| Done
+    InReview -.->|review requests changes| ChangesRequested
+    ChangesRequested -->|author pushes fix| InReview
 ```
 
 | State | What it means |
 |---|---|
 | **Backlog** | Issue exists, no PRD/plan yet. |
-| **Ready** | PRD + Dev plan written *and* refined after a sub-agent review. Sittable on the shelf, fully scoped. |
+| **Ready** | PRD + Dev plan written and unambiguous (an implementer can pick it up without asking the author). Sub-agent review is optional — use it when scope is complex or sequencing is non-obvious. |
 | **In progress** | Branch exists, code being written. |
-| **In review** | PR open, CI green, awaiting human. |
+| **In review** | PR open, CI green, awaiting reviewer (human or `gh-pr-review` skill). |
+| **Changes requested** | Reviewer requested changes; author is iterating on the same branch/PR. Goes back to **In review** on the next push. |
 | **Done** | Merged on `main`, CI green on `main`. |
+
+**Reviewers**: a human and the `gh-pr-review` skill have equal authority to approve and merge. The skill enforces its own gates (see `.claude/skills/gh-pr-review/SKILL.md` §4b); a human can override at any time.
+
+**Implementers**: a human and the `implement-task` skill (runs as `weavejamtom`, claims one Ready task per `/loop` tick) have equal authority to take Ready tasks. See `.claude/skills/implement-task/SKILL.md`.
 
 **Hard rules** (Claude must obey, automatically):
 
-1. **Move the card immediately on every transition.** Use `scripts/board.sh <issue> <Backlog|Ready|InProgress|InReview|Done>`. Don't batch.
-2. **Backlog → Ready requires sub-agent review.** Write PRD + Dev plan into the issue body, then spawn a sub-agent (`Plan` or `general-purpose`) to critique both, then fold the feedback in. Only then move to Ready.
+1. **Move the card immediately on every transition.** Use `scripts/board.sh <issue> <Backlog|Ready|InProgress|InReview|ChangesRequested|Done>`. Don't batch.
+2. **Backlog → Ready requires a clear PRD + Dev plan in the issue body.** "Clear" = an implementer can start without asking the author. Sub-agent review (`Plan` or `general-purpose`) is optional — reach for it when scope is complex, sequencing is non-obvious, or you'd otherwise hand-wave edge cases.
 3. **No PR while in Backlog or Ready.** Move to In progress first.
 4. **Done = merged on `main` + CI green on `main`.** Not "approved", not "branch ready".
-5. **Review requests changes → back to In progress.**
+5. **Review requests changes → Changes requested.** Author iterates on the same PR; the next push moves the card back to In review (the implementer / pusher is responsible for that transition).
 6. **Abandoned task → close issue with reason; don't strand the card.**
 
 #### PRD vs. Dev plan
@@ -99,7 +106,7 @@ Both go in the issue body, in labeled sections.
 - **PRD** — *what & why*. Problem, goal, scope, non-goals, acceptance criteria.
 - **Dev plan** — *how*. Files to add/modify, public APIs, test strategy, risks, commit sequence inside the PR.
 
-Sub-agent's job: poke holes in scope, sequencing, missing edge cases, simpler alternatives.
+Sub-agent (when used): poke holes in scope, sequencing, missing edge cases, simpler alternatives.
 
 ### Commits
 
@@ -131,3 +138,20 @@ See `docs/adding-a-game.md`.
 - Don't commit `.godot/` cache or build output (gitignored).
 - Don't open a PR without a backing issue.
 - Don't mark a card Done with red CI.
+
+## 8. Learning log
+
+Goal: don't repeat the same mistake twice. Get smarter over time.
+
+**When to write a learning note.** You hit ≥ 2 failed attempts of the same kind in this session (wrong tool flag, wrong assumption about an API, wrong determinism source, wrong CI invocation, …) before landing on what worked. One-shot fixes don't qualify — only patterns that *cost time* and that future-you would benefit from knowing up front.
+
+**How.**
+
+1. Create `docs/learning/yyyy-mm-dd-<short-english-slug>.md` with two sections:
+   - **Context** — what you were trying to do, what kept failing, why the wrong attempts looked plausible.
+   - **Solution** — what actually worked, and the underlying reason (so the lesson generalizes).
+2. Append one line to `docs/learning/index.md`:
+   `- [yyyy-mm-dd-<slug>.md](yyyy-mm-dd-<slug>.md) — <one-sentence context>. <one-sentence solution>.`
+3. Keep both terse. The note is a tripwire for next time, not a postmortem.
+
+**When to read.** At the start of any task that touches an area you've previously logged about (Godot CI, movie maker, determinism, board automation, …), skim `docs/learning/index.md` first.

--- a/docs/learning/2026-05-03-gh-identity-lubobill1990.md
+++ b/docs/learning/2026-05-03-gh-identity-lubobill1990.md
@@ -12,10 +12,10 @@ type: feedback
 
 For any GitHub operation against `lubobill1990/little-games` (enabling Pages, editing repo settings, dispatching workflows, creating releases, opening PRs from the owner's perspective, …):
 
-1. Run `gh auth switch --user lubobill1990` first if not already active. Verify with `gh auth status | head -5`.
+1. Export a process-scoped token: `export GH_TOKEN=$(gh auth token --user lubobill1990)`. Verify with `gh api user --jq .login` (must print `lubobill1990`). **Do not** run `gh auth switch` — it mutates `~/.config/gh/hosts.yml` and races the `implement-task` skill (which expects `weavejamtom` to be the active account). `GH_TOKEN` is process-scoped and overrides the active account for that shell only.
 2. Then proceed with the operation directly — **do not** ask the user to do it manually in the browser or via `! gh ...`. The user has authorized this identity and explicitly wants Claude to act as `lubobill1990` autonomously.
-3. The `weavejamtom` identity is reserved for the `implement-task` skill (claiming Ready tasks). Don't switch back unless that skill is running.
+3. The `weavejamtom` identity is reserved for the `implement-task` skill (claiming Ready tasks). The two identities coexist in the gh keyring; `GH_TOKEN` selects which one a given shell uses without touching the shared `hosts.yml`.
 
 **Why:** user said "为了 web deploy 正确性，你帮我直接用 lubobill1990 的身份操作 ... 后续需要用 lubobill1990 的身份进行 github 操作时，都自主操作，而不需要让我手动来" (2026-05-03). Asking them to click through GitHub Settings UI defeats the point of having the token.
 
-**How to apply:** before any `gh` / GitHub API call in this repo, check active account; switch to `lubobill1990` if needed; execute. Skip confirmation for read ops and routine writes (Pages enable, workflow rerun, label edits). Still confirm before destructive ops (delete repo, force-push to main, delete branches with unmerged work) per the global "executing actions with care" rule.
+**How to apply:** before any `gh` / GitHub API call in this repo, export `GH_TOKEN` for `lubobill1990` and execute. Skip confirmation for read ops and routine writes (Pages enable, workflow rerun, label edits). Still confirm before destructive ops (delete repo, force-push to main, delete branches with unmerged work) per the global "executing actions with care" rule.

--- a/docs/learning/2026-05-03-gh-identity-lubobill1990.md
+++ b/docs/learning/2026-05-03-gh-identity-lubobill1990.md
@@ -1,0 +1,21 @@
+---
+name: GitHub identity for this repo
+description: Default to lubobill1990 for any gh / GitHub API operation in this repo; do not ask the user to run things manually.
+type: feedback
+---
+
+# Context
+
+`gh auth status` on this machine shows two accounts: `weavejamtom` (the implementer-skill identity) and `lubobill1990` (the repo owner). The active one was `weavejamtom`, so commands like `gh api repos/lubobill1990/little-games/pages` ran as the wrong user and either hit 404 or lacked permission to enable Pages, repo settings, etc.
+
+# Solution
+
+For any GitHub operation against `lubobill1990/little-games` (enabling Pages, editing repo settings, dispatching workflows, creating releases, opening PRs from the owner's perspective, …):
+
+1. Run `gh auth switch --user lubobill1990` first if not already active. Verify with `gh auth status | head -5`.
+2. Then proceed with the operation directly — **do not** ask the user to do it manually in the browser or via `! gh ...`. The user has authorized this identity and explicitly wants Claude to act as `lubobill1990` autonomously.
+3. The `weavejamtom` identity is reserved for the `implement-task` skill (claiming Ready tasks). Don't switch back unless that skill is running.
+
+**Why:** user said "为了 web deploy 正确性，你帮我直接用 lubobill1990 的身份操作 ... 后续需要用 lubobill1990 的身份进行 github 操作时，都自主操作，而不需要让我手动来" (2026-05-03). Asking them to click through GitHub Settings UI defeats the point of having the token.
+
+**How to apply:** before any `gh` / GitHub API call in this repo, check active account; switch to `lubobill1990` if needed; execute. Skip confirmation for read ops and routine writes (Pages enable, workflow rerun, label edits). Still confirm before destructive ops (delete repo, force-push to main, delete branches with unmerged work) per the global "executing actions with care" rule.

--- a/docs/learning/index.md
+++ b/docs/learning/index.md
@@ -1,0 +1,8 @@
+# Learning log
+
+Notes from mistakes that cost time. See CLAUDE.md §8 for the policy.
+
+Format: `- [yyyy-mm-dd-slug.md](yyyy-mm-dd-slug.md) — <context>. <solution>.`
+
+<!-- entries below, newest first -->
+- [2026-05-03-gh-identity-lubobill1990.md](2026-05-03-gh-identity-lubobill1990.md) — gh CLI had two accounts active and defaulted to the wrong one for repo-owner ops. Switch to `lubobill1990` and act autonomously for any GitHub operation in this repo.

--- a/docs/learning/index.md
+++ b/docs/learning/index.md
@@ -5,4 +5,4 @@ Notes from mistakes that cost time. See CLAUDE.md §8 for the policy.
 Format: `- [yyyy-mm-dd-slug.md](yyyy-mm-dd-slug.md) — <context>. <solution>.`
 
 <!-- entries below, newest first -->
-- [2026-05-03-gh-identity-lubobill1990.md](2026-05-03-gh-identity-lubobill1990.md) — gh CLI had two accounts active and defaulted to the wrong one for repo-owner ops. Switch to `lubobill1990` and act autonomously for any GitHub operation in this repo.
+- [2026-05-03-gh-identity-lubobill1990.md](2026-05-03-gh-identity-lubobill1990.md) — gh CLI had two accounts active and defaulted to the wrong one for repo-owner ops. Use a process-scoped `GH_TOKEN` for `lubobill1990` and act autonomously for any GitHub operation in this repo.

--- a/scripts/board.sh
+++ b/scripts/board.sh
@@ -2,7 +2,7 @@
 # scripts/board.sh — move a Project board card by issue number.
 #
 # Usage:
-#   scripts/board.sh <issue-number> <Backlog|Ready|InProgress|InReview|Done>
+#   scripts/board.sh <issue-number> <Backlog|Ready|InProgress|InReview|ChangesRequested|Done>
 #
 # Why this script exists:
 #   The CLAUDE.md task workflow requires Claude to keep the Project board in
@@ -17,15 +17,16 @@ PROJECT_ID="PVT_kwHOAAnKBM4BWZYr"
 STATUS_FIELD_ID="PVTSSF_lAHOAAnKBM4BWZYrzhRuER4"
 
 declare -A STATUS_OPTION=(
-  [Backlog]="f75ad846"
-  [Ready]="61e4505c"
-  [InProgress]="47fc9ee4"
-  [InReview]="df73e18b"
-  [Done]="98236657"
+  [Backlog]="c159f539"
+  [Ready]="391bc048"
+  [InProgress]="52594841"
+  [InReview]="43a760f0"
+  [ChangesRequested]="4c71b2f8"
+  [Done]="bb829f92"
 )
 
 if [[ $# -ne 2 ]]; then
-  echo "Usage: $0 <issue-number> <Backlog|Ready|InProgress|InReview|Done>" >&2
+  echo "Usage: $0 <issue-number> <Backlog|Ready|InProgress|InReview|ChangesRequested|Done>" >&2
   exit 2
 fi
 


### PR DESCRIPTION
Closes #57.

## Summary

- **ChangesRequested state**: mermaid + state table now show `InReview -.-> ChangesRequested -> InReview`. Captures the period where a reviewer asked for fixes and the author is iterating; the next push moves the card back. `scripts/board.sh` learns the new arg + refreshed Project field option IDs.
- **Sub-agent review is now optional**, not mandatory, on Backlog → Ready. New bar: PRD + Dev plan must be unambiguous enough that an implementer can start without asking the author. Reach for sub-agent review when scope is complex or sequencing is non-obvious.
- **Skills as first-class actors**: `gh-pr-review` (reviewer) and `implement-task` (implementer, runs as `weavejamtom`) named in CLAUDE.md with same authority as a human, pointers to their `SKILL.md` files.
- **§8 Learning log convention**: when (≥2 failed attempts of the same kind in one session), how (`docs/learning/yyyy-mm-dd-<slug>.md` + index entry), when to read (skim index at task start). First entry — gh CLI identity for repo-owner ops — included so the convention has a working example.
- **`.gitignore`**: skill state files + worktree dirs (`.claude/gh-pr-review-state.json`, `.pr-review-worktrees/`, `.implement-task-state.json`, `.implement-task-worktrees/`, `.e2e-worktree/`) so a careless `git add` can't commit per-machine state.

## How tested

- **Mermaid render**: GitHub PR preview renders the new flowchart without syntax errors.
- **`board.sh` smoke**: ran `bash scripts/board.sh 57 Backlog → Ready → InProgress` during issue prep, all transitions landed against the live Project board with the refreshed option IDs. Will run `→ InReview` after this PR opens (and `→ ChangesRequested` if the reviewer pushes back).
- **Gitignore smoke**: `git status` on this checkout shows no skill-state files leaking in (`.claude/`, `.pr-review-worktrees/`, etc. either don't exist locally or are caught by the new patterns; `.claude/` itself is intentionally not ignored since it can hold project-checked-in `skills/`).
- **No code changes**: CI is green by construction; only docs + script + gitignore.

## Out of scope

- Skill behavior changes (`gh-pr-review` gates, `implement-task` claim protocol). Those live in their respective `SKILL.md` files; CLAUDE.md just points there to avoid duplication.
- Backfilling old learning notes — only the one we already had.