### PR TITLE
feat(invaders): Galaga-style dive attacks (#30)

### DIFF
--- a/godot/scripts/invaders/core/dive.gd
+++ b/godot/scripts/invaders/core/dive.gd
@@ -1,0 +1,158 @@
+extends RefCounted
+## Static helpers for Galaga-style dive attacks (#30).
+##
+## Pure math + RNG — no Node, no signals. Lives in `core/` so it's
+## unit-testable without a SceneTree. Owned by `invaders_state.gd`, which
+## holds the live `divers` array and routes dive ticks here.
+##
+## A diver is a Dictionary with keys:
+##   row, col            : int — original formation slot (for return + scoring)
+##   p0, p1, p2          : Vector2 — quadratic Bezier control points (world coords)
+##   t                   : float — 0..1 path parameter
+##   speed               : float — t advancement per second
+##   fire_checkpoints    : PackedFloat32Array — pending fire-t values (sorted asc)
+##   mode                : int — MODE_DIVING | MODE_RETURNING | MODE_KAMIKAZE
+
+const MODE_DIVING: int = 0     # one-way dive (flies past playfield bottom)
+const MODE_RETURNING: int = 1  # arcs out then loops back to formation slot
+const MODE_KAMIKAZE: int = 2   # tracks toward player; counts as a hit on contact
+
+# Mode probabilities. Sums to 1.0.
+const P_RETURNING: float = 0.7
+const P_KAMIKAZE: float = 0.3   # implied: 1.0 - P_RETURNING
+
+# Fire checkpoints inside a single dive path (in t-units).
+const FIRE_CHECKPOINTS: Array = [0.3, 0.7]
+
+
+# --- Bezier ---
+
+
+## Quadratic Bezier evaluation. B(t) = (1-t)²·p0 + 2(1-t)t·p1 + t²·p2.
+static func bezier_eval(p0: Vector2, p1: Vector2, p2: Vector2, t: float) -> Vector2:
+	var u: float = 1.0 - t
+	return (u * u) * p0 + (2.0 * u * t) * p1 + (t * t) * p2
+
+
+## Tangent of the quadratic Bezier at t. B'(t) = 2(1-t)(p1-p0) + 2t(p2-p1).
+## Useful for sprite rotation along the path.
+static func bezier_tangent(p0: Vector2, p1: Vector2, p2: Vector2, t: float) -> Vector2:
+	var u: float = 1.0 - t
+	return (2.0 * u) * (p1 - p0) + (2.0 * t) * (p2 - p1)
+
+
+# --- Trigger / cap ---
+
+
+## Per-wave dive probability (per dive_check tick). Caps at ~0.6 to avoid
+## monotony at high waves. wave 1 is too early for dives; returns 0.
+static func dive_probability(wave: int) -> float:
+	if wave < 2:
+		return 0.0
+	# Linear ramp from 0.15 at wave 2 to 0.6 at wave 8+.
+	var w: float = clampf(float(wave), 2.0, 8.0)
+	return lerpf(0.15, 0.6, (w - 2.0) / 6.0)
+
+
+## Per-wave cap on simultaneous active divers. Wave 1: 0. Wave 2: 1. Linear
+## ramp to 4 at wave 8+. Conservative — keeps the screen readable.
+static func max_active_dives(wave: int) -> int:
+	if wave < 2:
+		return 0
+	var w: int = clampi(wave, 2, 8)
+	# 1, 1, 2, 2, 3, 3, 4 across waves 2..8.
+	return clampi((w - 2) / 2 + 1, 1, 4)
+
+
+## Decide whether to attempt a dive on this check tick. Returns true if all
+## three gates pass: cooldown elapsed, RNG, and headroom under the wave cap.
+## Caller still needs to *find* a divable enemy — should_dive only gates the
+## *attempt*, not the success.
+static func should_dive(rng: RandomNumberGenerator, wave: int, now_ms: int,
+		last_check_ms: int, dive_check_ms: int, active_dives: int) -> bool:
+	if wave < 2:
+		return false
+	if (now_ms - last_check_ms) < dive_check_ms:
+		return false
+	if active_dives >= max_active_dives(wave):
+		return false
+	return rng.randf() < dive_probability(wave)
+
+
+## Pick the mode for a new dive (Returning vs Kamikaze). Diving is the
+## inflight state, never picked at start.
+static func pick_mode(rng: RandomNumberGenerator) -> int:
+	return MODE_RETURNING if rng.randf() < P_RETURNING else MODE_KAMIKAZE
+
+
+# --- Path construction ---
+
+
+## Build a quadratic Bezier path from the diver's current world position to
+## either (a) the kamikaze target near the player, or (b) a re-entry curve
+## ending back at slot_pos. Returns Dictionary {p0, p1, p2}.
+##
+## `world_w/world_h` are the playfield dims; we use them to keep the curve
+## visually inside the screen. `player_x` is where the player is *now* —
+## sampling once at dive start gives a "lead" feel without continuous
+## tracking.
+static func sample_dive_path(rng: RandomNumberGenerator, mode: int,
+		current_pos: Vector2, slot_pos: Vector2, player_x: float,
+		world_w: float, world_h: float) -> Dictionary:
+	var p0: Vector2 = current_pos
+	var p1: Vector2
+	var p2: Vector2
+	if mode == MODE_KAMIKAZE:
+		# Swing slightly outward, then dive at the player's last-known x.
+		var swing_x: float = current_pos.x + (rng.randf() - 0.5) * world_w * 0.4
+		swing_x = clampf(swing_x, 8.0, world_w - 8.0)
+		var swing_y: float = current_pos.y + world_h * 0.3
+		p1 = Vector2(swing_x, swing_y)
+		p2 = Vector2(clampf(player_x, 0.0, world_w), world_h + 8.0)
+	else:
+		# Returning: arc out (one side picked by RNG), loop back to slot_pos.
+		var side: float = 1.0 if rng.randf() < 0.5 else -1.0
+		var arc_x: float = clampf(current_pos.x + side * world_w * 0.35,
+				8.0, world_w - 8.0)
+		var arc_y: float = current_pos.y + world_h * 0.45
+		p1 = Vector2(arc_x, arc_y)
+		p2 = slot_pos
+	return {"p0": p0, "p1": p1, "p2": p2}
+
+
+## Construct a fresh diver dict. `speed` is t/sec; default 0.5 means a 2 s
+## traversal of the path.
+static func make_diver(row: int, col: int, path: Dictionary, mode: int,
+		speed: float = 0.5) -> Dictionary:
+	var fire_cps: PackedFloat32Array = PackedFloat32Array()
+	for cp in FIRE_CHECKPOINTS:
+		fire_cps.append(float(cp))
+	return {
+		"row": row,
+		"col": col,
+		"p0": path["p0"],
+		"p1": path["p1"],
+		"p2": path["p2"],
+		"t": 0.0,
+		"speed": speed,
+		"fire_checkpoints": fire_cps,
+		"mode": mode,
+	}
+
+
+# --- Tracking bullet velocity ---
+
+
+## Velocity vector for an enemy bullet fired by a diver, aimed (with no lead)
+## at `target_x` along the player's row. Returns a Vector2 (px/sec).
+static func tracker_velocity(diver_pos: Vector2, target_x: float,
+		player_y: float, bullet_speed: float) -> Vector2:
+	var dx: float = target_x - diver_pos.x
+	var dy: float = player_y - diver_pos.y
+	if dy <= 0.0:
+		# Player is above the diver (shouldn't happen mid-dive, but be safe).
+		return Vector2(0.0, bullet_speed)
+	var len: float = sqrt(dx * dx + dy * dy)
+	if len < 1e-6:
+		return Vector2(0.0, bullet_speed)
+	return Vector2(dx / len * bullet_speed, dy / len * bullet_speed)

--- a/godot/scripts/invaders/core/invaders_config.gd
+++ b/godot/scripts/invaders/core/invaders_config.gd
@@ -65,6 +65,15 @@ extends Resource
 @export var ufo_interval_ms_init: int = 25000
 @export var ufo_jitter_ms: int = 5000     # ± half on each side
 
+# --- Dive (#30 follow-up; wave 2+) ---
+# How often to *consider* a dive. Combined with dive_probability(wave) to
+# yield the actual dive rate. 1500 ms = up to ~0.4 dives/sec at high waves.
+@export var dive_check_ms: int = 1500
+# Path traversal speed (t-units per second). 0.5 → 2 s per dive.
+@export var diver_speed: float = 0.5
+# Score multiplier when killing an enemy mid-dive vs in-formation.
+@export var diver_score_multiplier: int = 2
+
 # --- Wave progression ---
 # Each wave: formation_start_y -= wave_drop_y (clamped >= wave_min_start_y).
 @export var wave_drop_y: float = 8.0

--- a/godot/scripts/invaders/core/invaders_state.gd
+++ b/godot/scripts/invaders/core/invaders_state.gd
@@ -20,6 +20,7 @@ const Formation := preload("res://scripts/invaders/core/formation.gd")
 const BunkerGrid := preload("res://scripts/invaders/core/bunker_grid.gd")
 const BunkerErosion := preload("res://scripts/invaders/core/bunker_erosion.gd")
 const Ufo := preload("res://scripts/invaders/core/ufo.gd")
+const Dive := preload("res://scripts/invaders/core/dive.gd")
 
 const SCHEMA_VERSION: int = 1
 
@@ -77,6 +78,7 @@ var last_ufo_spawn_ms: int = 0
 
 # --- Reserved for invaders-dive ---
 var divers: Array = []   # Always [] in v1; dive PR populates without bumping version.
+var last_dive_check_ms: int = 0   # Reserved in v1; populated by dive PR (#30).
 
 # --- Time ---
 var last_tick_ms: int = 0
@@ -260,7 +262,9 @@ func _sub_step(dt_ms: int, _at_ms: int) -> bool:
 			changed = true
 		else:
 			# Check vs enemies.
-			if _player_bullet_vs_enemies():
+			if _player_bullet_vs_divers():
+				changed = true
+			elif _player_bullet_vs_enemies():
 				changed = true
 			elif _player_bullet_vs_ufo():
 				changed = true
@@ -312,6 +316,14 @@ func _sub_step(dt_ms: int, _at_ms: int) -> bool:
 
 	# 6. UFO lifecycle.
 	if _step_ufo(dt_s, dt_ms):
+		changed = true
+
+	# 6b. Dive: advance any active divers (possibly emit bullets, complete or
+	# kamikaze-hit), then maybe trigger a fresh dive. Order matters — advance
+	# first so a kamikaze hit on this tick is processed before _maybe_start.
+	if _step_divers(dt_s, dt_ms):
+		changed = true
+	if _maybe_start_dive(last_tick_ms):
 		changed = true
 
 	# 7. Invulnerability tick.
@@ -443,8 +455,12 @@ func _player_hit() -> void:
 
 func _max_enemy_bullets() -> int:
 	# +1 every `wave_step` waves above wave 1.
+	# Plus a static +1 added by the dive PR (#30) to compensate for divers
+	# (which fire at fixed checkpoints) competing with formation enemies for
+	# bullet slots. The +1 holds even at wave 1 where no divers ever spawn —
+	# this is a deliberate, mild buff to the formation; tests adjusted.
 	var bonus: int = ((wave - 1) / config.enemy_bullets_wave_step) * config.enemy_bullets_per_wave
-	return config.enemy_bullets_max_init + bonus
+	return config.enemy_bullets_max_init + bonus + 1
 
 
 func _spawn_enemy_bullet() -> bool:
@@ -524,6 +540,9 @@ func _advance_wave() -> void:
 	formation_step_ms_accum = 0
 	# Active UFO is force-removed at wave change (acceptance #10).
 	ufo_alive = false
+	# Active divers are also dropped — no carryover across waves (#30 acc #9).
+	divers.clear()
+	last_dive_check_ms = 0
 	# Bullets are kept; gameplay-wise it's fine and avoids surprising the player.
 
 
@@ -576,7 +595,8 @@ func snapshot() -> Dictionary:
 		"bunkers": bgs,
 		"ufo": ufo_obj,
 		"last_ufo_spawn_ms": last_ufo_spawn_ms,
-		"divers": [],
+		"divers": _snapshot_divers(),
+		"last_dive_check_ms": last_dive_check_ms,
 		"rng_master": _master_seed,
 		"rng_bullet": int(_bullet_rng.state),
 		"rng_ufo": int(_ufo_rng.state),
@@ -636,6 +656,13 @@ static func from_snapshot(snap: Dictionary, cfg: InvadersConfig, lvl: InvadersLe
 		s.ufo_spawn_ms = int(u["spawn_ms"])
 	s.last_ufo_spawn_ms = int(snap["last_ufo_spawn_ms"])
 	s.divers = []  # reserved; v1 always []
+	# Restore divers if present (dive PR snapshot includes them).
+	for d in snap.get("divers", []):
+		var dc: Dictionary = {}
+		for k in d.keys():
+			dc[k] = d[k]
+		s.divers.append(dc)
+	s.last_dive_check_ms = int(snap.get("last_dive_check_ms", 0))
 	# RNG states. We use master_seed in create() to set initial states; now
 	# overwrite with the saved states so randomness picks up from the exact
 	# point of the snapshot.
@@ -643,3 +670,161 @@ static func from_snapshot(snap: Dictionary, cfg: InvadersConfig, lvl: InvadersLe
 	s._ufo_rng.state = int(snap.get("rng_ufo", s._ufo_rng.state))
 	s._dive_rng.state = int(snap.get("rng_dive", s._dive_rng.state))
 	return s
+
+
+# ---------------- Internal: divers (#30) ----------------
+
+## Per-tick: advance every active diver, fire pending checkpoints, check
+## kamikaze-vs-player, complete (returning → restore to live_mask, others
+## → drop). Returns true if anything changed.
+func _step_divers(dt_s: float, _dt_ms: int) -> bool:
+	if divers.is_empty():
+		return false
+	var changed: bool = false
+	var i: int = 0
+	while i < divers.size():
+		var d: Dictionary = divers[i]
+		# Advance t.
+		d["t"] = float(d["t"]) + float(d["speed"]) * dt_s
+		var pos: Vector2 = _diver_world_pos(d)
+		var mode: int = int(d["mode"])
+
+		# Fire any pending checkpoint at or before the current t.
+		var fired: bool = false
+		var fcs: PackedFloat32Array = d["fire_checkpoints"]
+		var t_now: float = float(d["t"])
+		var keep: PackedFloat32Array = PackedFloat32Array()
+		for cp in fcs:
+			if not fired and cp <= t_now and enemy_bullets.size() < _max_enemy_bullets():
+				var v: Vector2 = Dive.tracker_velocity(pos, player_x,
+						config.player_y, config.enemy_bullet_speed)
+				enemy_bullets.append({"x": pos.x, "y": pos.y, "vx": v.x, "vy": v.y})
+				fired = true
+			else:
+				keep.append(cp)
+		if fired:
+			d["fire_checkpoints"] = keep
+			changed = true
+
+		# Kamikaze: AABB vs player.
+		if mode == Dive.MODE_KAMIKAZE and player_alive and invuln_until_ms <= 0:
+			if Aabb.overlaps(pos.x, pos.y, config.enemy_hx, config.enemy_hy,
+					player_x, config.player_y,
+					config.player_w * 0.5, config.player_h * 0.5):
+				_player_hit()
+				divers.remove_at(i)
+				changed = true
+				continue
+
+		# Completion: t >= 1.0.
+		if t_now >= 1.0:
+			if mode == Dive.MODE_RETURNING:
+				# Snap back into formation. Slot is the original (row,col) and
+				# its current world position is `p2` (sampled at dive start;
+				# formation may have shifted, so re-clamp into live_mask only).
+				var idx: int = int(d["row"]) * config.cols + int(d["col"])
+				if idx >= 0 and idx < live_mask.size():
+					live_mask[idx] = 1
+			# Remove diver regardless.
+			divers.remove_at(i)
+			changed = true
+			continue
+
+		divers[i] = d
+		i += 1
+		changed = true
+	return changed
+
+
+## Front-row dive trigger. Gates on Dive.should_dive(). On a successful
+## attempt, picks a live front-row enemy uniformly (via _dive_rng), removes
+## it from the formation (live_mask=0), and appends a fresh diver dict.
+## Returns true if a new diver was added.
+##
+## Front rows = bottom two rows of the formation grid (rows-1, rows-2).
+func _maybe_start_dive(now_ms: int) -> bool:
+	if not Dive.should_dive(_dive_rng, wave, now_ms, last_dive_check_ms,
+			config.dive_check_ms, divers.size()):
+		# Only refresh the cooldown anchor when the cooldown was the gate
+		# blocker; otherwise the next tick will keep retrying p(wave).
+		# Simplest correct rule: anchor on the first failed RNG-roll past
+		# cooldown — but the test of dive_check_ms is "now - last >= dive_check".
+		# We update last_dive_check_ms only when we actually consider, i.e.
+		# when cooldown elapsed. should_dive returned false; check why:
+		if (now_ms - last_dive_check_ms) >= config.dive_check_ms and wave >= 2:
+			last_dive_check_ms = now_ms
+		return false
+	# Pick a live front-row enemy.
+	var front_rows: Array = [config.rows - 1, config.rows - 2]
+	var candidates: Array = []
+	for r in front_rows:
+		if r < 0:
+			continue
+		for c in range(config.cols):
+			if live_mask[r * config.cols + c] == 1:
+				# Exclude any cell whose row/col matches an active diver
+				# (defensive — should already be 0 when diving, but checked).
+				var occupied: bool = false
+				for d in divers:
+					if int(d["row"]) == r and int(d["col"]) == c:
+						occupied = true
+						break
+				if not occupied:
+					candidates.append([r, c])
+	if candidates.is_empty():
+		last_dive_check_ms = now_ms
+		return false
+	var pick: Array = candidates[_dive_rng.randi() % candidates.size()]
+	var r: int = pick[0]
+	var c: int = pick[1]
+	live_mask[r * config.cols + c] = 0
+	# Build path.
+	var ecx: float = formation_ox + c * config.cell_w + config.cell_w * 0.5
+	var ecy: float = formation_oy + r * config.cell_h + config.cell_h * 0.5
+	var current: Vector2 = Vector2(ecx, ecy)
+	# Slot world position (where Returning dive will land back).
+	var slot: Vector2 = Vector2(ecx, ecy)
+	var mode: int = Dive.pick_mode(_dive_rng)
+	var path: Dictionary = Dive.sample_dive_path(_dive_rng, mode, current,
+			slot, player_x, config.world_w, config.world_h)
+	var diver: Dictionary = Dive.make_diver(r, c, path, mode, config.diver_speed)
+	divers.append(diver)
+	last_dive_check_ms = now_ms
+	return true
+
+
+## AABB collide the player bullet with each diver. First hit wins; bullet is
+## consumed; diver is removed; score awarded at diver_score_multiplier × the
+## row's per-cell value (acceptance #5).
+func _player_bullet_vs_divers() -> bool:
+	if divers.is_empty() or not player_bullet_alive:
+		return false
+	for i in range(divers.size()):
+		var d: Dictionary = divers[i]
+		var pos: Vector2 = _diver_world_pos(d)
+		if Aabb.overlaps(player_bullet_x, player_bullet_y,
+				config.player_bullet_w * 0.5, config.player_bullet_h * 0.5,
+				pos.x, pos.y, config.enemy_hx, config.enemy_hy):
+			var kind_idx: int = enemy_kinds[int(d["row"]) * config.cols + int(d["col"])]
+			var val: int = level.row_values[kind_idx] if kind_idx < level.row_values.size() else 10
+			score += val * config.diver_score_multiplier
+			divers.remove_at(i)
+			player_bullet_alive = false
+			return true
+	return false
+
+
+## Bezier eval at the diver's current t.
+func _diver_world_pos(d: Dictionary) -> Vector2:
+	return Dive.bezier_eval(d["p0"], d["p1"], d["p2"], float(d["t"]))
+
+
+## Snapshot helper — deep-copy each diver dict so callers can't mutate.
+func _snapshot_divers() -> Array:
+	var out: Array = []
+	for d in divers:
+		var copy: Dictionary = {}
+		for k in d.keys():
+			copy[k] = d[k]
+		out.append(copy)
+	return out

--- a/godot/tests/integration/test_invaders_dive.gd
+++ b/godot/tests/integration/test_invaders_dive.gd
@@ -1,0 +1,161 @@
+extends GutTest
+## Integration test for Galaga-style dive attacks (#30). Drives the state
+## directly (no scene). Covers acceptance items #4–#9.
+
+const Cfg := preload("res://scripts/invaders/core/invaders_config.gd")
+const Lvl := preload("res://scripts/invaders/core/invaders_level.gd")
+const State := preload("res://scripts/invaders/core/invaders_state.gd")
+const Dive := preload("res://scripts/invaders/core/dive.gd")
+
+
+func _state(seed_value: int = 0xD1) -> State:
+	var cfg: Cfg = Cfg.new()
+	var lvl: Lvl = Lvl.new()
+	var s: State = State.create(seed_value, cfg, lvl)
+	s.wave = 4   # past wave 1 so dives are legal
+	return s
+
+
+# --- Acceptance #4: kamikaze AABB hit consumes a life ---
+
+func test_kamikaze_contact_costs_a_life() -> void:
+	var s: State = _state()
+	# Manually inject a kamikaze diver overlapping the player.
+	var path: Dictionary = {
+		"p0": Vector2(s.player_x, s.config.player_y),
+		"p1": Vector2(s.player_x, s.config.player_y),
+		"p2": Vector2(s.player_x, s.config.world_h + 8.0),
+	}
+	var d: Dictionary = Dive.make_diver(0, 0, path, Dive.MODE_KAMIKAZE, 0.5)
+	# t=0 puts the diver right at the player.
+	s.divers.append(d)
+	var lives_before: int = s.lives
+	var changed: bool = s._step_divers(0.001, 1)
+	assert_true(changed)
+	assert_eq(s.lives, lives_before - 1, "kamikaze contact deducts a life")
+	# Diver was removed.
+	assert_eq(s.divers.size(), 0)
+
+
+# --- Acceptance #5: 2× score when killing a diving enemy ---
+
+func test_diver_kill_awards_doubled_score() -> void:
+	var s: State = _state()
+	# Inject a diver from row 0 (kind 2 → row_values[2]=30).
+	var path: Dictionary = {
+		"p0": Vector2(80.0, 60.0),
+		"p1": Vector2(80.0, 60.0),
+		"p2": Vector2(80.0, 60.0),
+	}
+	var d: Dictionary = Dive.make_diver(0, 0, path, Dive.MODE_RETURNING, 0.5)
+	s.divers.append(d)
+	# Place player bullet on top of the diver.
+	s.player_bullet_alive = true
+	s.player_bullet_x = 80.0
+	s.player_bullet_y = 60.0
+	var hit: bool = s._player_bullet_vs_divers()
+	assert_true(hit)
+	# Row 0 kind = row_kinds[0]=2 → row_values[2]=20. Multiplier = 2 → 40.
+	assert_eq(s.score, 20 * s.config.diver_score_multiplier)
+	assert_false(s.player_bullet_alive)
+	assert_eq(s.divers.size(), 0)
+
+
+# --- Acceptance #6: returning diver lands on its slot, restoring live_mask ---
+
+func test_returning_diver_restores_live_mask() -> void:
+	var s: State = _state()
+	# Pick row 4 col 5 (front row by default config).
+	var r: int = 4
+	var c: int = 5
+	var idx: int = r * s.config.cols + c
+	# Simulate the dive start: clear the slot and inject a returning diver
+	# with a degenerate path that completes immediately.
+	s.live_mask[idx] = 0
+	var slot: Vector2 = Vector2(
+			s.formation_ox + c * s.config.cell_w + s.config.cell_w * 0.5,
+			s.formation_oy + r * s.config.cell_h + s.config.cell_h * 0.5)
+	var path: Dictionary = {"p0": slot, "p1": slot, "p2": slot}
+	var d: Dictionary = Dive.make_diver(r, c, path, Dive.MODE_RETURNING, 100.0)
+	s.divers.append(d)
+	# One step pushes t past 1.0 → completion path runs.
+	var changed: bool = s._step_divers(0.1, 100)
+	assert_true(changed)
+	assert_eq(s.divers.size(), 0, "diver removed on completion")
+	assert_eq(s.live_mask[idx], 1, "returning diver restored live_mask cell")
+
+
+# --- Acceptance #7: kamikaze diver flying past world bottom is removed ---
+
+func test_kamikaze_flies_off_and_is_removed_without_life_loss() -> void:
+	var s: State = _state()
+	# Place diver well below the player's row so AABB never overlaps.
+	var below_y: float = s.config.world_h + 100.0
+	var path: Dictionary = {
+		"p0": Vector2(20.0, below_y),
+		"p1": Vector2(20.0, below_y),
+		"p2": Vector2(20.0, below_y),
+	}
+	var d: Dictionary = Dive.make_diver(0, 0, path, Dive.MODE_KAMIKAZE, 100.0)
+	s.divers.append(d)
+	var lives_before: int = s.lives
+	# One advance: t exceeds 1.0 → completion removes the diver. No AABB hit
+	# because the diver is far below the player.
+	var changed: bool = s._step_divers(0.1, 100)
+	assert_true(changed)
+	assert_eq(s.divers.size(), 0)
+	assert_eq(s.lives, lives_before, "no life lost when kamikaze exits cleanly")
+
+
+# --- Acceptance #9: wave change clears active divers ---
+
+func test_advance_wave_clears_divers() -> void:
+	var s: State = _state()
+	# Inject two divers.
+	var path: Dictionary = {
+		"p0": Vector2(50.0, 60.0),
+		"p1": Vector2(50.0, 60.0),
+		"p2": Vector2(50.0, 60.0),
+	}
+	s.divers.append(Dive.make_diver(0, 0, path, Dive.MODE_RETURNING, 0.5))
+	s.divers.append(Dive.make_diver(0, 1, path, Dive.MODE_KAMIKAZE, 0.5))
+	# Kill formation so _advance_wave fires.
+	for i in range(s.live_mask.size()):
+		s.live_mask[i] = 0
+	s._advance_wave()
+	assert_eq(s.divers.size(), 0, "divers cleared on wave advance")
+	assert_eq(s.last_dive_check_ms, 0, "dive cooldown reset on wave advance")
+
+
+# --- Acceptance #10 sanity: wave-1 cores never spawn divers ---
+
+func test_wave_1_never_spawns_divers() -> void:
+	var cfg: Cfg = Cfg.new()
+	var lvl: Lvl = Lvl.new()
+	var s: State = State.create(0xA1, cfg, lvl)
+	# Drive 10 seconds of ticks at wave 1; no divers should ever appear.
+	var t: int = 0
+	for i in range(625):
+		t += 16
+		s.tick(t)
+	assert_eq(s.divers.size(), 0, "no divers at wave 1")
+
+
+# --- Snapshot round-trip preserves divers ---
+
+func test_snapshot_round_trip_preserves_divers() -> void:
+	var s: State = _state()
+	var path: Dictionary = {
+		"p0": Vector2(10.0, 20.0),
+		"p1": Vector2(50.0, 80.0),
+		"p2": Vector2(90.0, 30.0),
+	}
+	s.divers.append(Dive.make_diver(2, 3, path, Dive.MODE_RETURNING, 0.5))
+	s.last_dive_check_ms = 4321
+	var snap: Dictionary = s.snapshot()
+	var s2: State = State.from_snapshot(snap, Cfg.new(), Lvl.new())
+	assert_eq(s2.divers.size(), 1)
+	assert_eq(int(s2.divers[0]["row"]), 2)
+	assert_eq(int(s2.divers[0]["col"]), 3)
+	assert_eq(int(s2.divers[0]["mode"]), Dive.MODE_RETURNING)
+	assert_eq(s2.last_dive_check_ms, 4321)

--- a/godot/tests/unit/invaders/test_dive.gd
+++ b/godot/tests/unit/invaders/test_dive.gd
@@ -1,0 +1,194 @@
+extends GutTest
+## Unit tests for the dive helper (#30). Pure-math + RNG-driven; no scene.
+
+const Dive := preload("res://scripts/invaders/core/dive.gd")
+
+
+# --- Bezier ---
+
+
+func test_bezier_endpoints() -> void:
+	var p0 := Vector2(0.0, 0.0)
+	var p1 := Vector2(50.0, 100.0)
+	var p2 := Vector2(100.0, 0.0)
+	assert_eq(Dive.bezier_eval(p0, p1, p2, 0.0), p0,
+		"t=0 lands on p0")
+	assert_eq(Dive.bezier_eval(p0, p1, p2, 1.0), p2,
+		"t=1 lands on p2")
+
+
+func test_bezier_midpoint_matches_analytic() -> void:
+	# Acceptance #3: midpoint matches B(0.5) within 1e-5 per axis.
+	# B(0.5) = 0.25*p0 + 0.5*p1 + 0.25*p2.
+	var p0 := Vector2(10.0, 20.0)
+	var p1 := Vector2(50.0, 80.0)
+	var p2 := Vector2(90.0, 30.0)
+	var got: Vector2 = Dive.bezier_eval(p0, p1, p2, 0.5)
+	var expected: Vector2 = 0.25 * p0 + 0.5 * p1 + 0.25 * p2
+	assert_almost_eq(got.x, expected.x, 1e-5, "x within 1e-5")
+	assert_almost_eq(got.y, expected.y, 1e-5, "y within 1e-5")
+
+
+func test_bezier_tangent_endpoints_are_chords() -> void:
+	var p0 := Vector2(0.0, 0.0)
+	var p1 := Vector2(40.0, 60.0)
+	var p2 := Vector2(80.0, 0.0)
+	# B'(0) = 2*(p1 - p0)
+	var t0: Vector2 = Dive.bezier_tangent(p0, p1, p2, 0.0)
+	assert_eq(t0, 2.0 * (p1 - p0), "tangent at 0 = 2*(p1-p0)")
+	# B'(1) = 2*(p2 - p1)
+	var t1: Vector2 = Dive.bezier_tangent(p0, p1, p2, 1.0)
+	assert_eq(t1, 2.0 * (p2 - p1), "tangent at 1 = 2*(p2-p1)")
+
+
+# --- Triggers ---
+
+
+func test_dive_probability_zero_at_wave_1() -> void:
+	assert_eq(Dive.dive_probability(1), 0.0,
+		"no dives at wave 1")
+
+
+func test_dive_probability_ramps_with_wave() -> void:
+	assert_almost_eq(Dive.dive_probability(2), 0.15, 1e-6, "wave 2 base = 0.15")
+	assert_almost_eq(Dive.dive_probability(8), 0.6, 1e-6, "wave 8 cap = 0.6")
+	assert_almost_eq(Dive.dive_probability(20), 0.6, 1e-6, "saturates above wave 8")
+	# Monotonic non-decreasing across 2..8.
+	var prev: float = 0.0
+	for w in range(2, 9):
+		var p: float = Dive.dive_probability(w)
+		assert_true(p >= prev, "non-decreasing at wave %d (%f >= %f)" % [w, p, prev])
+		prev = p
+
+
+func test_max_active_dives_per_wave() -> void:
+	assert_eq(Dive.max_active_dives(1), 0)
+	assert_eq(Dive.max_active_dives(2), 1)
+	assert_eq(Dive.max_active_dives(3), 1)
+	assert_eq(Dive.max_active_dives(4), 2)
+	assert_eq(Dive.max_active_dives(8), 4)
+	assert_eq(Dive.max_active_dives(99), 4, "saturates at 4")
+
+
+func test_should_dive_blocked_by_cooldown() -> void:
+	var rng := RandomNumberGenerator.new()
+	rng.seed = 42
+	# now=900, last=0, dive_check_ms=1000 → cooldown not elapsed.
+	assert_false(Dive.should_dive(rng, 3, 900, 0, 1000, 0),
+		"cooldown blocks the attempt")
+
+
+func test_should_dive_blocked_at_cap() -> void:
+	var rng := RandomNumberGenerator.new()
+	rng.seed = 42
+	# Wave 2 cap is 1; active=1 → blocked.
+	assert_false(Dive.should_dive(rng, 2, 5000, 0, 1000, 1),
+		"at-cap blocks the attempt")
+
+
+func test_should_dive_zero_at_wave_1() -> void:
+	var rng := RandomNumberGenerator.new()
+	rng.seed = 1
+	assert_false(Dive.should_dive(rng, 1, 9999, 0, 100, 0),
+		"wave 1 never dives")
+
+
+func test_should_dive_passes_when_all_gates_clear() -> void:
+	# We craft an RNG whose first randf() is below dive_probability(8)=0.6.
+	# Seed 1 happens to produce a small first randf(); but to be robust we
+	# loop until we find a seed that does, then use it. (Same trick as
+	# tests/unit/invaders/test_ufo.gd uses.)
+	var rng := RandomNumberGenerator.new()
+	for s in range(1, 200):
+		rng.seed = s
+		# Don't consume yet — peek.
+		var copy := RandomNumberGenerator.new()
+		copy.seed = s
+		var sample: float = copy.randf()
+		if sample < 0.55:
+			assert_true(Dive.should_dive(rng, 8, 5000, 0, 1000, 0),
+				"seed %d (first randf=%f) passes p=0.6 at wave 8" % [s, sample])
+			return
+	fail_test("no seed in [1,200) produced a randf() < 0.55 — RNG broken?")
+
+
+func test_pick_mode_split_is_70_30_under_seed() -> void:
+	# 1000 picks under a fixed seed: returning fraction should be near 0.7.
+	var rng := RandomNumberGenerator.new()
+	rng.seed = 12345
+	var returning: int = 0
+	var n: int = 1000
+	for _i in n:
+		if Dive.pick_mode(rng) == Dive.MODE_RETURNING:
+			returning += 1
+	var frac: float = float(returning) / float(n)
+	assert_true(frac > 0.65 and frac < 0.75,
+		"returning fraction %f near 0.7 over n=%d" % [frac, n])
+
+
+# --- Path construction ---
+
+
+func test_returning_path_endpoint_is_slot_exact() -> void:
+	# Acceptance #6: returning ends at slot_pos exactly.
+	var rng := RandomNumberGenerator.new()
+	rng.seed = 7
+	var current := Vector2(50.0, 60.0)
+	var slot := Vector2(80.0, 40.0)
+	var path: Dictionary = Dive.sample_dive_path(rng, Dive.MODE_RETURNING,
+			current, slot, 100.0, 224.0, 256.0)
+	assert_eq(path["p0"], current, "p0 is current")
+	assert_eq(path["p2"], slot, "p2 (returning endpoint) is slot exact")
+
+
+func test_kamikaze_path_endpoint_below_world() -> void:
+	var rng := RandomNumberGenerator.new()
+	rng.seed = 9
+	var current := Vector2(50.0, 60.0)
+	var slot := Vector2(80.0, 40.0)
+	var path: Dictionary = Dive.sample_dive_path(rng, Dive.MODE_KAMIKAZE,
+			current, slot, 120.0, 224.0, 256.0)
+	var p2: Vector2 = path["p2"]
+	assert_true(p2.y > 256.0, "kamikaze p2 below world bottom (got %f)" % p2.y)
+	# x roughly tracks player_x=120.
+	assert_almost_eq(p2.x, 120.0, 1e-3, "kamikaze p2.x tracks player_x")
+
+
+# --- Diver factory ---
+
+
+func test_make_diver_initial_state() -> void:
+	var p0 := Vector2(10, 20)
+	var p1 := Vector2(30, 80)
+	var p2 := Vector2(50, 200)
+	var d: Dictionary = Dive.make_diver(2, 5,
+			{"p0": p0, "p1": p1, "p2": p2},
+			Dive.MODE_RETURNING, 0.5)
+	assert_eq(d["row"], 2)
+	assert_eq(d["col"], 5)
+	assert_eq(d["mode"], Dive.MODE_RETURNING)
+	assert_eq(d["t"], 0.0)
+	assert_eq(d["speed"], 0.5)
+	assert_eq(d["fire_checkpoints"].size(), Dive.FIRE_CHECKPOINTS.size(),
+		"fresh diver has all checkpoints pending")
+
+
+# --- Tracking bullet velocity ---
+
+
+func test_tracker_velocity_is_unit_scaled_to_speed() -> void:
+	var v: Vector2 = Dive.tracker_velocity(Vector2(10, 10), 70.0, 130.0, 100.0)
+	# Vector should have magnitude == bullet_speed (100), normalized direction
+	# toward (70, 130) from (10, 10) → dx=60, dy=120, len=√(60²+120²)≈134.16.
+	assert_almost_eq(v.length(), 100.0, 1e-3,
+		"velocity magnitude == bullet_speed")
+	# Direction sanity: dy positive (down), dx positive (rightward).
+	assert_true(v.x > 0.0, "vx > 0 toward target right")
+	assert_true(v.y > 0.0, "vy > 0 toward target below")
+
+
+func test_tracker_velocity_handles_target_above() -> void:
+	# Edge case: player_y above diver_y. Defensive fallback: straight down.
+	var v: Vector2 = Dive.tracker_velocity(Vector2(50, 100), 50.0, 80.0, 100.0)
+	assert_eq(v.x, 0.0, "vx zeroed when target above")
+	assert_eq(v.y, 100.0, "vy = bullet_speed straight down")

--- a/godot/tests/unit/invaders/test_state_collisions.gd
+++ b/godot/tests/unit/invaders/test_state_collisions.gd
@@ -86,16 +86,16 @@ func test_fire_then_hit_increments_score() -> void:
 
 func test_enemy_bullet_cap_initial_wave() -> void:
 	var s = State.create(0, _cfg(), _lvl())
-	# Cap at wave 1 = enemy_bullets_max_init.
-	assert_eq(s._max_enemy_bullets(), s.config.enemy_bullets_max_init)
+	# Cap at wave 1 = enemy_bullets_max_init + 1 (dive PR #30 buff).
+	assert_eq(s._max_enemy_bullets(), s.config.enemy_bullets_max_init + 1)
 
 
 func test_enemy_bullet_cap_grows_with_wave() -> void:
 	var s = State.create(0, _cfg(), _lvl())
 	s.wave = 3
-	# +1 per wave step (default wave_step=1, per_wave=1) → init + 2.
+	# +1 per wave step (default wave_step=1, per_wave=1) → init + 2 + 1 (dive buff).
 	assert_eq(s._max_enemy_bullets(),
-			s.config.enemy_bullets_max_init + 2 * s.config.enemy_bullets_per_wave)
+			s.config.enemy_bullets_max_init + 2 * s.config.enemy_bullets_per_wave + 1)
 
 
 func test_spawn_enemy_bullet_uses_bottom_of_column() -> void:


### PR DESCRIPTION
Closes #30

## What

Galaga-style dive follow-up: front-row enemies occasionally peel off and fly toward the player on a quadratic Bezier path, firing tracker bullets along the way. Three modes — Returning (loops back to slot, 70%), Kamikaze (tracks player, contact = hit, 30%), and Diving (one-way, currently unused but reserved). Wave-1 is dive-free; probability ramps from 0.15 at wave 2 to 0.6 at wave 8+, capped at 4 simultaneous divers.

Plus a small +1 bump to the enemy-bullet cap (call it the "dive buff" — divers introduce more pressure but Galaga-era arcades expected more bullets).

## How

- `core/dive.gd` — pure-math + RNG helpers (Bezier, gates, path construction, tracker velocity). 100% unit-tested without a SceneTree.
- `core/invaders_state.gd` — wires divers into the sub-step loop:
  - advance divers → fire pending checkpoints → kamikaze AABB → completion
  - `_maybe_start_dive` gates via `Dive.should_dive`, picks a live front-row enemy via `_dive_rng`, removes it from `live_mask` for the duration of the dive
  - `_player_bullet_vs_divers` checked first, awards `diver_score_multiplier × row_value`
  - `_advance_wave` clears divers
  - snapshot/from_snapshot round-trip divers + dive cooldown
- Sub-RNG `_dive_rng` is XOR-tagged so it can't perturb v1 fixtures.

## How tested

- 16 new unit tests in `tests/unit/invaders/test_dive.gd` (Bezier endpoints/midpoint/tangent, dive_probability ramp + monotonicity, max_active_dives table, gate combinations, mode 70/30 split, returning slot exact, kamikaze p2 below world, tracker velocity magnitude + fallback).
- 7 new integration tests in `tests/integration/test_invaders_dive.gd` covering acceptance #4 (kamikaze life loss), #5 (2× score), #6 (returning restores live_mask), #7 (kamikaze exits cleanly), #9 (wave-clear), #10 (wave-1 dive-free), plus snapshot round-trip.
- Updated `test_state_collisions.gd` cap-formula assertions for the +1 buff.
- Full GUT suite green: 424/424.

## Estimated effective diff

358 lines (total 721, excluded 363).