### PR TITLE
feat(snake): SFX, haptics, persistent best per difficulty (#19)

### DIFF
--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -20,6 +20,7 @@ Keys are dotted paths. Per-game keys are prefixed with the game's `id` (also use
 | `input.binding.<action>.<slot>` | `Dictionary` | #5b          | rebind slot — `<slot> ∈ {kbd, pad}` |
 | `tetris.high_score`      | `int`          | bootstrap          | live key in `globals/settings.gd`; rename to `tetris.best` is a backlog cleanup |
 | `snake.best.<difficulty>` | `int`         | snake-polish (#19) | `<difficulty> ∈ {easy, normal, hard}` |
+| `snake.last_difficulty`  | `String`       | snake-polish (#19) | last-picked difficulty id; default `normal` |
 | `g2048.best`             | `int`          | 2048-polish (#21)  | 4×4 only in v1 |
 | `breakout.best.level_NN` | `int`          | breakout-polish (#23) | per-level high score |
 | `breakout.best.run`      | `int`          | breakout-polish (#23) | best score across the full level pack |

--- a/godot/scenes/snake/snake.gd
+++ b/godot/scenes/snake/snake.gd
@@ -14,6 +14,11 @@ const Board := preload("res://scenes/snake/view/board.gd")
 const HUD := preload("res://scenes/snake/view/hud.gd")
 const PauseOverlay := preload("res://scenes/snake/view/pause_overlay.gd")
 const GameOverOverlay := preload("res://scenes/snake/view/game_over_overlay.gd")
+const StartScreen := preload("res://scenes/snake/view/start_screen.gd")
+const Difficulty := preload("res://scripts/snake/difficulty.gd")
+const SfxTones := preload("res://scripts/core/audio/sfx_tones.gd")
+const SfxVolume := preload("res://scripts/core/audio/sfx_volume.gd")
+const Haptics := preload("res://scripts/core/input/haptics.gd")
 
 # GameHost contract.
 signal exit_requested()
@@ -22,21 +27,38 @@ signal score_reported(value: int)
 # Touch swipe threshold (px). Smaller swipes are ignored.
 const SWIPE_MIN_PX: float = 24.0
 
-enum Phase { PLAYING, PAUSED, GAME_OVER }
+# Haptic intensities (intensity 0..1, duration ms) — eat = quick, death = long.
+const _EAT_HAPTIC: Array = [0.3, 80]
+const _GAME_OVER_HAPTIC: Array = [0.7, 250]
+
+enum Phase { PICKING, PLAYING, PAUSED, GAME_OVER }
 
 @onready var board: Node2D = $HBox/BoardHost/Board
 @onready var hud: VBoxContainer = $HBox/Side/HUD
 @onready var pause_overlay: CanvasLayer = $PauseOverlay
 @onready var game_over_overlay: CanvasLayer = $GameOverOverlay
+@onready var start_screen: CanvasLayer = $StartScreen
 
 var state: SnakeGameState
 var config: SnakeConfig
-var _phase: int = Phase.PLAYING
+var _phase: int = Phase.PICKING
 var _logical_now_ms: int = 0
 var _last_real_ms: int = 0
 var _started: bool = false
 var _last_reported_score: int = -1
 var _seed: int = 0
+var _difficulty_id: String = Difficulty.DEFAULT_ID
+var _best_score: int = 0
+
+# SFX players keyed by event name; populated by _setup_sfx.
+var _sfx_players: Dictionary = {}
+# Default audio sink is `self`; tests override via _inject_audio.
+var _audio: Object
+
+# Snapshot diff tracking for audio dispatch.
+var _last_score: int = 0
+var _last_level: int = 1
+var _last_game_over: bool = false
 
 # Touch swipe tracking. -1 = no active touch.
 var _touch_index: int = -1
@@ -45,29 +67,49 @@ var _touch_start: Vector2 = Vector2.ZERO
 func _ready() -> void:
 	pause_overlay.visible = false
 	game_over_overlay.visible = false
+	_setup_sfx()
+	if _audio == null:
+		_audio = self
 	InputManager.action_pressed.connect(_on_action_pressed)
 	InputManager.action_repeated.connect(_on_action_repeated)
 	game_over_overlay.restart_requested.connect(_on_restart_pressed)
 	game_over_overlay.menu_requested.connect(_on_menu_pressed)
 	pause_overlay.menu_requested.connect(_on_menu_pressed)
+	start_screen.difficulty_chosen.connect(_on_difficulty_chosen)
+	if _has_settings():
+		Settings.changed.connect(_on_settings_changed)
+		_apply_sfx_volume()
 	# Standalone launch (project main_scene == us; or scene loaded directly in
-	# a test). Auto-start with a deterministic seed (0). Tests override state.
+	# a test). Show difficulty picker; tests bypass via start().
 	if get_tree().current_scene == self:
-		start(0)
+		_show_difficulty_picker()
 
 # --- GameHost contract ---
 
-func start(seed_value: int = 0) -> void:
+func start(seed_value: int = 0, difficulty_id: String = "") -> void:
 	_seed = seed_value
+	if difficulty_id == "":
+		difficulty_id = _difficulty_id
+	_difficulty_id = difficulty_id
+	var d: Dictionary = Difficulty.by_id(_difficulty_id)
 	config = SnakeConfig.new()
+	config.start_step_ms = int(d["start_step_ms"])
+	config.walls = bool(d["walls"])
 	state = SnakeGameState.create(_seed, config)
 	board.configure(config.grid_w, config.grid_h, config.walls)
+	hud.set_difficulty(String(d["title"]))
 	_phase = Phase.PLAYING
 	_logical_now_ms = 0
 	_last_real_ms = _real_now()
 	_last_reported_score = -1
+	_last_score = 0
+	_last_level = 1
+	_last_game_over = false
+	_best_score = int(Settings.get_value(Difficulty.best_key(_difficulty_id), 0)) if _has_settings() else 0
 	pause_overlay.visible = false
 	game_over_overlay.visible = false
+	if start_screen != null:
+		start_screen.visible = false
 	_started = true
 	_update_views()
 
@@ -130,6 +172,7 @@ func _update_views() -> void:
 	var snap: Dictionary = state.snapshot()
 	board.update_from_snapshot(snap)
 	hud.update_from_snapshot(snap)
+	_audio_dispatch(snap)
 	var s: int = int(snap.get("score", 0))
 	if s != _last_reported_score:
 		_last_reported_score = s
@@ -200,16 +243,135 @@ func _enter_game_over() -> void:
 	if _phase == Phase.GAME_OVER:
 		return
 	_phase = Phase.GAME_OVER
+	_persist_best()
 	var snap: Dictionary = state.snapshot()
-	game_over_overlay.show_with(int(snap.get("score", 0)), int(snap.get("level", 1)))
+	game_over_overlay.show_with(int(snap.get("score", 0)), int(snap.get("level", 1)), _best_score)
 
 func _on_restart_pressed() -> void:
 	game_over_overlay.visible = false
-	# Fresh seed for replay; tests override start() afterwards if needed.
-	start(_seed + 1)
+	# Fresh seed for replay; keep the same difficulty.
+	start(_seed + 1, _difficulty_id)
 
 func _on_menu_pressed() -> void:
 	exit_requested.emit()
 
 func _real_now() -> int:
 	return Time.get_ticks_msec()
+
+
+# --- Audio (procedural tones; no asset files) ---
+
+func _setup_sfx() -> void:
+	_register_oneshot(&"eat", SfxTones.tone_sequence([
+		Vector2(660.0, 0.04), Vector2(880.0, 0.06),
+	], 0.4))
+	_register_oneshot(&"level_up", SfxTones.tone_sequence([
+		Vector2(523.0, 0.06), Vector2(659.0, 0.06), Vector2(784.0, 0.10),
+	], 0.45))
+	_register_oneshot(&"game_over", SfxTones.tone_sequence([
+		Vector2(330.0, 0.10), Vector2(247.0, 0.16), Vector2(165.0, 0.28),
+	], 0.5))
+
+
+func _register_oneshot(key: StringName, stream: AudioStream) -> void:
+	var p: AudioStreamPlayer = AudioStreamPlayer.new()
+	p.stream = stream
+	add_child(p)
+	_sfx_players[key] = p
+
+
+func _has_settings() -> bool:
+	return get_tree().root.has_node("Settings")
+
+
+func _apply_sfx_volume() -> void:
+	if not _has_settings():
+		return
+	var master: float = float(Settings.get_value(&"audio.master", 1.0))
+	var sfx: float = float(Settings.get_value(&"audio.sfx", 1.0))
+	var v: float = SfxVolume.linear_volume(master, sfx)
+	for p in _sfx_players.values():
+		if p != null:
+			SfxVolume.set_player_volume(p, v)
+
+
+func _on_settings_changed(key: StringName) -> void:
+	var s: String = String(key)
+	if s == "audio.master" or s == "audio.sfx":
+		_apply_sfx_volume()
+
+
+## Default audio sink: `_audio.play(key)` lands here unless a test injects a
+## recorder via `_inject_audio` before start().
+func play(key: StringName) -> void:
+	var p: AudioStreamPlayer = _sfx_players.get(key, null)
+	if p != null:
+		p.stop()
+		p.play()
+
+
+## Test seam: replace the SFX dispatcher with a recorder. Recorder must
+## implement `play(StringName)`.
+func _inject_audio(audio: Object) -> void:
+	_audio = audio
+
+
+## Compare current snapshot against last; route audio + haptic events.
+## Acceptance #1: each gameplay event listed under SFX produces an audible cue.
+## Acceptance #2: eat triggers a haptic pulse.
+func _audio_dispatch(snap: Dictionary) -> void:
+	var s: int = int(snap.get("score", 0))
+	var lvl: int = int(snap.get("level", 1))
+	var go: bool = bool(snap.get("game_over", false))
+	if s > _last_score:
+		_audio.play(&"eat")
+		Haptics.pulse(float(_EAT_HAPTIC[0]), int(_EAT_HAPTIC[1]))
+	if lvl > _last_level:
+		_audio.play(&"level_up")
+	if go and not _last_game_over:
+		_audio.play(&"game_over")
+		Haptics.pulse(float(_GAME_OVER_HAPTIC[0]), int(_GAME_OVER_HAPTIC[1]))
+	_last_score = s
+	_last_level = lvl
+	_last_game_over = go
+
+
+# --- Persistence ---
+
+func _persist_best() -> void:
+	if not _has_settings() or state == null:
+		return
+	var key: StringName = Difficulty.best_key(_difficulty_id)
+	var s: int = int(state.snapshot().get("score", 0))
+	var prior: int = int(Settings.get_value(key, 0))
+	if s > prior:
+		Settings.set_value(key, s)
+		_best_score = s
+
+
+# --- Difficulty picker ---
+
+func _show_difficulty_picker() -> void:
+	_phase = Phase.PICKING
+	_started = false
+	pause_overlay.visible = false
+	game_over_overlay.visible = false
+	var initial: String = Difficulty.DEFAULT_ID
+	if _has_settings():
+		initial = String(Settings.get_value(Difficulty.LAST_KEY, Difficulty.DEFAULT_ID))
+	start_screen.show_picker(initial)
+
+
+func _on_difficulty_chosen(id: String) -> void:
+	_difficulty_id = id
+	if _has_settings():
+		Settings.set_value(Difficulty.LAST_KEY, id)
+	start(0, id)
+
+
+# --- Test seam ---
+
+func _refresh_views_for_test() -> void:
+	if state == null:
+		return
+	_update_views()

--- a/godot/scenes/snake/snake.tscn
+++ b/godot/scenes/snake/snake.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=6 format=3 uid="uid://bsnakeroot01"]
+[gd_scene load_steps=7 format=3 uid="uid://bsnakeroot01"]
 
 [ext_resource type="Script" path="res://scenes/snake/snake.gd" id="1_root"]
 [ext_resource type="Script" path="res://scenes/snake/view/board.gd" id="2_board"]
 [ext_resource type="Script" path="res://scenes/snake/view/hud.gd" id="3_hud"]
 [ext_resource type="Script" path="res://scenes/snake/view/pause_overlay.gd" id="4_pause"]
 [ext_resource type="Script" path="res://scenes/snake/view/game_over_overlay.gd" id="5_over"]
+[ext_resource type="Script" path="res://scenes/snake/view/start_screen.gd" id="6_start"]
 
 [node name="Snake" type="Control"]
 anchors_preset = 15
@@ -43,3 +44,6 @@ script = ExtResource("4_pause")
 
 [node name="GameOverOverlay" type="CanvasLayer" parent="."]
 script = ExtResource("5_over")
+
+[node name="StartScreen" type="CanvasLayer" parent="."]
+script = ExtResource("6_start")

--- a/godot/scenes/snake/view/game_over_overlay.gd
+++ b/godot/scenes/snake/view/game_over_overlay.gd
@@ -7,6 +7,7 @@ signal menu_requested()
 
 var _score_label: Label
 var _level_label: Label
+var _best_label: Label
 var _menu_btn: Button
 
 func _ready() -> void:
@@ -35,6 +36,10 @@ func _ready() -> void:
 	_level_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	_level_label.add_theme_font_size_override("font_size", 18)
 	vbox.add_child(_level_label)
+	_best_label = Label.new()
+	_best_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	_best_label.add_theme_font_size_override("font_size", 18)
+	vbox.add_child(_best_label)
 	var hint := Label.new()
 	hint.text = "Press Confirm to retry"
 	hint.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
@@ -47,9 +52,10 @@ func _ready() -> void:
 	InputManager.action_pressed.connect(_on_action_pressed)
 	visible = false
 
-func show_with(score: int, level: int) -> void:
+func show_with(score: int, level: int, best: int = 0) -> void:
 	_score_label.text = "Final Score: %d" % score
 	_level_label.text = "Level: %d" % level
+	_best_label.text = "Best: %d" % best
 	visible = true
 
 func _on_action_pressed(action: StringName) -> void:

--- a/godot/scenes/snake/view/hud.gd
+++ b/godot/scenes/snake/view/hud.gd
@@ -1,21 +1,24 @@
 extends VBoxContainer
-## Snake HUD: score, level, step rate. Updated by parent on every visible
-## state change.
+## Snake HUD: score, level, step rate, difficulty. Updated by parent on every
+## visible state change.
 
 const Palette := preload("res://scripts/snake/cell_palette.gd")
 
 var _score_label: Label
 var _level_label: Label
 var _step_label: Label
+var _difficulty_label: Label
 
 func _ready() -> void:
 	add_theme_constant_override("separation", 8)
 	_score_label = _make_label("Score: 0", 28)
 	_level_label = _make_label("Level: 1", 18)
 	_step_label = _make_label("Step: 200ms", 14)
+	_difficulty_label = _make_label("", 14)
 	add_child(_score_label)
 	add_child(_level_label)
 	add_child(_step_label)
+	add_child(_difficulty_label)
 
 func _make_label(text: String, font_size: int) -> Label:
 	var l := Label.new()
@@ -28,3 +31,6 @@ func update_from_snapshot(snap: Dictionary) -> void:
 	_score_label.text = "Score: %d" % int(snap.get("score", 0))
 	_level_label.text = "Level: %d" % int(snap.get("level", 1))
 	_step_label.text = "Step: %dms" % int(snap.get("step_ms", 0))
+
+func set_difficulty(title: String) -> void:
+	_difficulty_label.text = "Difficulty: %s" % title

--- a/godot/scenes/snake/view/start_screen.gd
+++ b/godot/scenes/snake/view/start_screen.gd
@@ -1,0 +1,125 @@
+extends CanvasLayer
+## Snake difficulty picker. Layer 5 (below pause/game-over). Three Buttons in
+## a row; first selection grabs focus so gamepad d-pad / left-stick navigates
+## natively. Confirm (A / Enter) emits `difficulty_chosen(id)`.
+##
+## Default selection is `Settings.snake.last_difficulty` (or `"normal"` if
+## absent). Per-difficulty best score is shown beneath each button.
+
+const Difficulty := preload("res://scripts/snake/difficulty.gd")
+
+signal difficulty_chosen(id: String)
+
+var _buttons: Array[Button] = []
+var _initial_focus_id: String = Difficulty.DEFAULT_ID
+
+
+func _ready() -> void:
+	layer = 5
+	var bg := ColorRect.new()
+	bg.color = Color(0, 0, 0, 0.85)
+	bg.anchor_right = 1.0
+	bg.anchor_bottom = 1.0
+	add_child(bg)
+	var vbox := VBoxContainer.new()
+	vbox.alignment = BoxContainer.ALIGNMENT_CENTER
+	vbox.anchor_right = 1.0
+	vbox.anchor_bottom = 1.0
+	vbox.add_theme_constant_override("separation", 24)
+	add_child(vbox)
+	var title := Label.new()
+	title.text = "SNAKE"
+	title.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	title.add_theme_font_size_override("font_size", 56)
+	vbox.add_child(title)
+	var prompt := Label.new()
+	prompt.text = "Pick a difficulty"
+	prompt.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	prompt.add_theme_font_size_override("font_size", 22)
+	vbox.add_child(prompt)
+	var row := HBoxContainer.new()
+	row.alignment = BoxContainer.ALIGNMENT_CENTER
+	row.add_theme_constant_override("separation", 24)
+	vbox.add_child(row)
+	for d in Difficulty.DIFFICULTIES:
+		var card: VBoxContainer = _build_card(d)
+		row.add_child(card)
+
+
+func _build_card(d: Dictionary) -> VBoxContainer:
+	var col := VBoxContainer.new()
+	col.alignment = BoxContainer.ALIGNMENT_CENTER
+	col.add_theme_constant_override("separation", 6)
+	var btn := Button.new()
+	btn.text = String(d["title"])
+	btn.custom_minimum_size = Vector2(160.0, 80.0)
+	btn.add_theme_font_size_override("font_size", 28)
+	var id: String = String(d["id"])
+	btn.pressed.connect(func() -> void: _emit_choice(id))
+	col.add_child(btn)
+	_buttons.append(btn)
+	var detail := Label.new()
+	detail.text = "%dms · %s" % [int(d["start_step_ms"]), "walls" if bool(d["walls"]) else "wrap"]
+	detail.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	detail.add_theme_font_size_override("font_size", 14)
+	col.add_child(detail)
+	var best := Label.new()
+	best.text = _best_label(id)
+	best.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	best.add_theme_font_size_override("font_size", 14)
+	col.add_child(best)
+	return col
+
+
+func _best_label(id: String) -> String:
+	if not _has_settings():
+		return "Best: 0"
+	var v: int = int(Settings.get_value(Difficulty.best_key(id), 0))
+	return "Best: %d" % v
+
+
+func _has_settings() -> bool:
+	return get_tree().root.has_node("Settings")
+
+
+## Set initial focus and reveal. Caller passes the id to default to (last
+## chosen, or `normal`). Wires focus_neighbor so d-pad left/right walk the row.
+func show_picker(initial_id: String = Difficulty.DEFAULT_ID) -> void:
+	_initial_focus_id = initial_id
+	visible = true
+	# Refresh best labels on each show — caller may have just persisted one.
+	for i in _buttons.size():
+		var card: VBoxContainer = _buttons[i].get_parent() as VBoxContainer
+		if card != null and card.get_child_count() >= 3:
+			var best_label: Label = card.get_child(2) as Label
+			if best_label != null:
+				best_label.text = _best_label(String(Difficulty.DIFFICULTIES[i]["id"]))
+	# Wire focus neighbours horizontally.
+	for i in _buttons.size():
+		var b: Button = _buttons[i]
+		var left: int = (i - 1 + _buttons.size()) % _buttons.size()
+		var right: int = (i + 1) % _buttons.size()
+		b.focus_neighbor_left = _buttons[left].get_path()
+		b.focus_neighbor_right = _buttons[right].get_path()
+	var idx: int = 0
+	for i in _buttons.size():
+		if String(Difficulty.DIFFICULTIES[i]["id"]) == _initial_focus_id:
+			idx = i
+			break
+	_buttons[idx].grab_focus()
+
+
+func _emit_choice(id: String) -> void:
+	if _has_settings():
+		Settings.set_value(Difficulty.LAST_KEY, id)
+	visible = false
+	difficulty_chosen.emit(id)
+
+
+func _input(event: InputEvent) -> void:
+	if not visible:
+		return
+	if event.is_action_pressed(&"ui_accept"):
+		var f: Control = get_viewport().gui_get_focus_owner()
+		if f is Button:
+			(f as Button).pressed.emit()

--- a/godot/scripts/snake/difficulty.gd
+++ b/godot/scripts/snake/difficulty.gd
@@ -1,0 +1,34 @@
+extends RefCounted
+## Snake difficulty buckets. Pure data — no Node, no signals.
+##
+## Each bucket maps to a (start_step_ms, walls) pair plus a stable id used as
+## the persistence-key suffix (`snake.best.<id>`, see docs/persistence.md).
+## `last_difficulty` is the most-recently-picked id, restored on scene re-entry.
+
+const DIFFICULTIES: Array = [
+	{"id": "easy",   "title": "Easy",   "start_step_ms": 180, "walls": false},
+	{"id": "normal", "title": "Normal", "start_step_ms": 130, "walls": true},
+	{"id": "hard",   "title": "Hard",   "start_step_ms":  90, "walls": true},
+]
+
+const DEFAULT_ID: String = "normal"
+const LAST_KEY: StringName = &"snake.last_difficulty"
+
+
+static func ids() -> Array:
+	var out: Array = []
+	for d in DIFFICULTIES:
+		out.append(String(d["id"]))
+	return out
+
+
+static func by_id(id: String) -> Dictionary:
+	for d in DIFFICULTIES:
+		if String(d["id"]) == id:
+			return d
+	return by_id(DEFAULT_ID)
+
+
+## Persistence key for a difficulty's best score: `snake.best.<id>`.
+static func best_key(id: String) -> StringName:
+	return StringName("snake.best.%s" % id)

--- a/godot/tests/integration/test_snake_audio_dispatch.gd
+++ b/godot/tests/integration/test_snake_audio_dispatch.gd
@@ -1,0 +1,90 @@
+extends GutTest
+## Snake polish (#19): SFX dispatch.
+##
+## Acceptance #1: each gameplay event (eat / level_up / game_over) produces
+## an audible cue. We verify by injecting a recorder and pumping snapshot
+## diffs through `_audio_dispatch`.
+
+const ActionMapDefaults := preload("res://scripts/core/input/action_map_defaults.gd")
+
+var scene: Control
+var rec: _Recorder
+
+
+class _Recorder:
+	extends RefCounted
+	var calls: Array = []
+	func play(key: StringName) -> void:
+		calls.append(key)
+	func keys() -> Array:
+		return calls
+
+
+func _settings() -> Node:
+	return Engine.get_main_loop().root.get_node("Settings")
+
+
+func before_each() -> void:
+	for action in ActionMapDefaults.ACTIONS:
+		Input.action_release(action)
+	_settings().reset_defaults()
+	await get_tree().process_frame
+	var packed: PackedScene = load("res://scenes/snake/snake.tscn")
+	scene = packed.instantiate()
+	add_child(scene)
+	await get_tree().process_frame
+	rec = _Recorder.new()
+	scene._inject_audio(rec)
+	scene.start(0, "normal")
+	await get_tree().process_frame
+	rec.calls.clear()
+
+
+func after_each() -> void:
+	for action in ActionMapDefaults.ACTIONS:
+		Input.action_release(action)
+	if is_instance_valid(scene):
+		scene.queue_free()
+	_settings().reset_defaults()
+	await get_tree().process_frame
+
+
+# --- Eat ---
+
+func test_score_increase_plays_eat() -> void:
+	scene.state._score = 1
+	scene._refresh_views_for_test()
+	assert_true(rec.keys().has(&"eat"), "eat played on score+1; got %s" % [rec.keys()])
+
+
+func test_no_eat_when_score_unchanged() -> void:
+	scene._refresh_views_for_test()
+	assert_false(rec.keys().has(&"eat"), "no eat when score didn't change")
+
+
+# --- Level up ---
+
+func test_level_increase_plays_level_up() -> void:
+	scene.state._level = 2
+	scene._refresh_views_for_test()
+	assert_true(rec.keys().has(&"level_up"),
+		"level_up played on level+1; got %s" % [rec.keys()])
+
+
+# --- Game over ---
+
+func test_game_over_plays_game_over_once() -> void:
+	scene.state._game_over = true
+	scene._refresh_views_for_test()
+	assert_eq(rec.keys().count(&"game_over"), 1, "game_over played once")
+	scene._refresh_views_for_test()
+	assert_eq(rec.keys().count(&"game_over"), 1, "game_over not retriggered")
+
+
+# --- Default audio sink wiring (no-recorder path) ---
+
+func test_default_play_no_throw_for_unknown_event() -> void:
+	# Removing the recorder, scene.play(key) should silently no-op for unknown.
+	scene._inject_audio(scene)
+	scene.play(&"never_registered")
+	assert_true(true, "default play() handled unknown key without error")

--- a/godot/tests/integration/test_snake_persistence.gd
+++ b/godot/tests/integration/test_snake_persistence.gd
@@ -1,0 +1,115 @@
+extends GutTest
+## Snake polish (#19): persistence + per-difficulty best.
+##
+## Acceptance #3: best score persists across app restart, scoped per
+## difficulty. Acceptance #4: difficulty selection threads through to
+## start_step_ms / walls. Acceptance #6: snake.last_difficulty round-trips.
+
+const ActionMapDefaults := preload("res://scripts/core/input/action_map_defaults.gd")
+const Difficulty := preload("res://scripts/snake/difficulty.gd")
+
+const SEED: int = 7777
+
+var scene: Control
+
+
+func _settings() -> Node:
+	return Engine.get_main_loop().root.get_node("Settings")
+
+
+func before_each() -> void:
+	for action in ActionMapDefaults.ACTIONS:
+		Input.action_release(action)
+	_settings().reset_defaults()
+	await get_tree().process_frame
+	var packed: PackedScene = load("res://scenes/snake/snake.tscn")
+	scene = packed.instantiate()
+	add_child(scene)
+	await get_tree().process_frame
+	# Default-start at normal so existing scene-test patterns still work.
+	scene.start(SEED, "normal")
+	await get_tree().process_frame
+
+
+func after_each() -> void:
+	for action in ActionMapDefaults.ACTIONS:
+		Input.action_release(action)
+	if is_instance_valid(scene):
+		scene.queue_free()
+	_settings().reset_defaults()
+	await get_tree().process_frame
+
+
+# --- Acceptance #3: best persists per difficulty ---
+
+func test_persists_new_best_on_game_over() -> void:
+	scene.state._score = 42
+	scene.state._game_over = true
+	scene._enter_game_over()
+	assert_eq(int(_settings().get_value(Difficulty.best_key("normal"), -1)), 42,
+		"score persisted to snake.best.normal")
+	assert_eq(scene._best_score, 42, "in-memory best updated")
+
+
+func test_does_not_overwrite_higher_existing_best() -> void:
+	_settings().set_value(Difficulty.best_key("normal"), 9999)
+	scene.start(SEED, "normal")
+	await get_tree().process_frame
+	scene.state._score = 100
+	scene.state._game_over = true
+	scene._enter_game_over()
+	assert_eq(int(_settings().get_value(Difficulty.best_key("normal"), -1)), 9999,
+		"existing higher best is preserved")
+
+
+func test_best_is_per_difficulty() -> void:
+	# Set distinct best scores per bucket; each must round-trip independently.
+	_settings().set_value(Difficulty.best_key("easy"), 11)
+	_settings().set_value(Difficulty.best_key("normal"), 22)
+	_settings().set_value(Difficulty.best_key("hard"), 33)
+	scene.start(SEED, "easy")
+	await get_tree().process_frame
+	assert_eq(scene._best_score, 11, "easy best loaded")
+	scene.start(SEED, "hard")
+	await get_tree().process_frame
+	assert_eq(scene._best_score, 33, "hard best loaded")
+
+
+# --- Acceptance #4: difficulty threads through to config ---
+
+func test_difficulty_threads_through_to_config() -> void:
+	scene.start(SEED, "easy")
+	await get_tree().process_frame
+	assert_false(scene.config.walls, "easy uses wrap")
+	assert_eq(scene.config.start_step_ms, 180, "easy step_ms")
+	scene.start(SEED, "hard")
+	await get_tree().process_frame
+	assert_true(scene.config.walls, "hard uses walls")
+	assert_eq(scene.config.start_step_ms, 90, "hard step_ms")
+
+
+func test_hud_shows_difficulty() -> void:
+	scene.start(SEED, "hard")
+	await get_tree().process_frame
+	assert_eq(scene.hud._difficulty_label.text, "Difficulty: Hard",
+		"HUD shows difficulty title")
+
+
+# --- Acceptance #6: last_difficulty persists ---
+
+func test_picker_choice_persists_last_difficulty() -> void:
+	scene._on_difficulty_chosen("hard")
+	await get_tree().process_frame
+	assert_eq(String(_settings().get_value(Difficulty.LAST_KEY, "")), "hard",
+		"last_difficulty saved on pick")
+
+
+func test_game_over_overlay_shows_best() -> void:
+	_settings().set_value(Difficulty.best_key("normal"), 555)
+	scene.start(SEED, "normal")
+	await get_tree().process_frame
+	scene.state._score = 50
+	scene.state._game_over = true
+	scene._enter_game_over()
+	assert_eq(scene.game_over_overlay._best_label.text, "Best: 555",
+		"overlay shows persisted best")

--- a/godot/tests/unit/snake/test_snake_difficulty.gd
+++ b/godot/tests/unit/snake/test_snake_difficulty.gd
@@ -1,0 +1,42 @@
+extends GutTest
+## Difficulty bucket data + key helpers (#19).
+
+const Difficulty := preload("res://scripts/snake/difficulty.gd")
+
+
+func test_three_difficulties() -> void:
+	var ids: Array = Difficulty.ids()
+	assert_eq(ids.size(), 3)
+	assert_true(ids.has("easy") and ids.has("normal") and ids.has("hard"))
+
+
+func test_default_id_is_normal() -> void:
+	assert_eq(Difficulty.DEFAULT_ID, "normal")
+
+
+func test_easy_uses_wrap_normal_and_hard_use_walls() -> void:
+	assert_false(bool(Difficulty.by_id("easy")["walls"]))
+	assert_true(bool(Difficulty.by_id("normal")["walls"]))
+	assert_true(bool(Difficulty.by_id("hard")["walls"]))
+
+
+func test_step_ms_is_monotonically_decreasing() -> void:
+	var e: int = int(Difficulty.by_id("easy")["start_step_ms"])
+	var n: int = int(Difficulty.by_id("normal")["start_step_ms"])
+	var h: int = int(Difficulty.by_id("hard")["start_step_ms"])
+	assert_true(e > n and n > h, "easy(%d) > normal(%d) > hard(%d)" % [e, n, h])
+
+
+func test_unknown_id_falls_back_to_default() -> void:
+	var d: Dictionary = Difficulty.by_id("nope")
+	assert_eq(String(d["id"]), Difficulty.DEFAULT_ID)
+
+
+func test_best_key_is_namespaced_per_difficulty() -> void:
+	assert_eq(String(Difficulty.best_key("easy")), "snake.best.easy")
+	assert_eq(String(Difficulty.best_key("normal")), "snake.best.normal")
+	assert_eq(String(Difficulty.best_key("hard")), "snake.best.hard")
+
+
+func test_last_key_constant() -> void:
+	assert_eq(String(Difficulty.LAST_KEY), "snake.last_difficulty")


### PR DESCRIPTION
Closes #19

## What

Round out Snake with SFX, haptics, persistent best score, and a difficulty selector (Easy/Normal/Hard).

- **Difficulty buckets** — easy uses wrap + 180ms steps; normal uses walls + 130ms; hard uses walls + 90ms. Selector is a CanvasLayer overlay shown on standalone launch (and after game-over via Restart of a new run); three Buttons in a row, focus_neighbor wired so gamepad d-pad navigates natively. Default selection is \`snake.last_difficulty\` (or \`normal\`).
- **SFX** — three procedural-tone events (eat / level_up / game_over) following the invaders pattern. Dispatched from snapshot diffs in \`_audio_dispatch\`. Test seam: \`_inject_audio(recorder)\` swaps the sink before \`start()\`.
- **Haptics** — \`Haptics.pulse(0.3, 80)\` on eat, \`Haptics.pulse(0.7, 250)\` on game over.
- **Persistence** — best score stored as \`snake.best.<id>\` (per difficulty); \`snake.last_difficulty\` round-trips the user's last pick. Both keys documented in \`docs/persistence.md\`.

## How tested

- \`tests/unit/snake/test_snake_difficulty.gd\` (7 tests) — bucket data, default, monotonic step_ms, fallback, key namespacing.
- \`tests/integration/test_snake_persistence.gd\` (7 tests) — best persists per difficulty, doesn't overwrite higher, threads through to config (walls + step_ms), HUD label, last_difficulty saved on pick, overlay shows best.
- \`tests/integration/test_snake_audio_dispatch.gd\` (5 tests) — eat on score+1, level_up on level+1, game_over once-only, no-op for unknown event.
- Full GUT suite green: 443/443.

## Estimated effective diff

386 lines (total 707, excluded 321).