### PR TITLE
ci: pages bootstrap, SHA-pinned actions, post-deploy verification (#39)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,14 @@ jobs:
       - name: Add .nojekyll
         run: touch build/web/.nojekyll
 
+      - name: Inject build marker
+        run: |
+          # Pages CDN can serve stale HTML; embed the commit SHA so the
+          # post-deploy check can prove it sees the bundle that was just built.
+          # See docs/learning/2026-05-03-pages-bootstrap.md.
+          sed -i "s|</head>|<meta name=\"build-sha\" content=\"${{ github.sha }}\"></head>|" build/web/index.html
+          grep -q "build-sha" build/web/index.html
+
       - name: Smoke-check exported files
         run: |
           test -s build/web/index.html
@@ -189,7 +197,15 @@ jobs:
           grep -q 'Engine' build/web/index.html
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        # Pinned to commit SHA (was @v5) per #39 — floating tags can be
+        # re-pointed; the failure class we hit was "trusted setup-time state",
+        # and SHA pinning closes a similar door. enablement:true bootstraps
+        # Pages on a fresh fork; in this repo Pages is already enabled, so it
+        # is a no-op here but matters for forks. See docs/learning/2026-05-03-
+        # pages-bootstrap.md for the full rationale (incl. PAT requirement).
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b
+        with:
+          enablement: true
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
@@ -198,4 +214,34 @@ jobs:
 
       - name: Deploy to Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        # Pinned to commit SHA (was @v4) per #39.
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e
+
+      - name: Post-deploy verification (assets + freshness)
+        run: |
+          # Verify the deploy actually served what we built. Three checks:
+          # (a) HEAD on the asset triplet returns 200,
+          # (b) GET on index.html contains the build-sha marker we injected,
+          # (c) the marker matches THIS run's commit (not stale CDN cache).
+          # 12×10s = 2 min retry budget — Pages CDN propagation has been
+          # observed to exceed 30s in practice. See #39 acceptance #2.
+          url="${{ steps.deployment.outputs.page_url }}"
+          expected="${{ github.sha }}"
+          for i in $(seq 1 12); do
+            ok=1
+            for asset in index.html index.wasm index.pck; do
+              code=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 10 -I "${url}${asset}" || echo 000)
+              [ "$code" = "200" ] || { echo "attempt $i: $asset → $code"; ok=0; break; }
+            done
+            if [ $ok -eq 1 ]; then
+              sha=$(curl -fsSL --max-time 10 "${url}index.html" | grep -oE 'build-sha" content="[a-f0-9]+"' | cut -d'"' -f3 || echo "")
+              if [ "$sha" = "$expected" ]; then
+                echo "live and fresh: $url (sha $sha)"
+                exit 0
+              fi
+              echo "attempt $i: served sha '$sha', expected '$expected'"
+            fi
+            sleep 10
+          done
+          echo "::error::post-deploy verification failed after 12×10s"
+          exit 1

--- a/docs/learning/2026-05-03-pages-bootstrap.md
+++ b/docs/learning/2026-05-03-pages-bootstrap.md
@@ -1,0 +1,26 @@
+# Pages bootstrap & branch protection
+
+## Context
+
+Issue #7 was moved to Done with red CI on `main` and an unreachable demo URL. Three consecutive `main` pushes (#34 [`d8df693`], #36 [`7d59e01`], #37) shipped red CI before manual remediation. Root cause: `actions/configure-pages@v5` defaults to `enablement: false`. The workflow looked correct on disk, but the repo had Pages disabled in settings — a state invisible from the workflow file. Compounding, the human merger merged each red PR without checking CI (CLAUDE.md §5 hard rule #4 violated three times). The skill-based reviewer (`gh-pr-review`) would have blocked on `gh pr checks`; the human did not.
+
+Bootstrap was applied manually on 2026-05-03:
+- `gh api -X POST repos/lubobill1990/little-games/pages -f build_type=workflow` enabled Pages with the Actions source.
+- `gh run rerun 25275117590 --failed` brought `main` green and the site back up.
+
+The site is live now, but **nothing in version control prevents the same failure on a fresh clone, fork, or accidental Pages-disable**, and **nothing prevents the human merger from again merging a red PR**.
+
+## Solution
+
+Three layers, all required:
+
+1. **Workflow self-bootstraps Pages.** `actions/configure-pages` is invoked with `enablement: true` and **pinned to a commit SHA** (`983d7736d9b0ae728b81ab479565c72886d7745b`, the v5 tag at task-author time), not a floating tag. Floating tags can be re-pointed; the failure class we hit was "trusted setup-time state", and SHA pinning closes a similar door. `actions/deploy-pages` is also pinned (`d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e`, the v4 tag at the same instant). One known caveat: per the upstream action's `action.yml` description, `enablement: true` requires a token with `administration:write` scope — the default `GITHUB_TOKEN` lacks this. In our repo Pages is already enabled, so this step is a no-op for us; for a fresh fork, the bootstrap will fail loudly with a 403, which is strictly better than the prior silent "Get Pages site failed ... Not Found" error.
+
+2. **Post-deploy verification, not just smoke.** After `actions/deploy-pages` succeeds, a step retries 12×10s checking three things in one pass:
+   - `HEAD` on `index.html`, `index.wasm`, `index.pck` each returns `200` (catches partial-asset deploys),
+   - `GET ${page_url}index.html` body contains a `<meta name="build-sha" content="...">` marker injected at build time,
+   - the marker matches `${{ github.sha }}` (catches stale-CDN serving — the Pages CDN has been observed to take >30s to propagate).
+
+3. **Branch protection on `main`.** Required status check: only the `ci / GUT (unit + integration)` job. Set via `gh api -X PUT .../branches/main/protection` after the PR merges (not a tracked file). Why only `test`: the `export-web` job is gated `if: github.event_name == 'push' && github.ref == 'refs/heads/main'` — it never runs on PRs, so requiring it would make every PR un-mergeable. Deploy correctness is enforced by the post-deploy verification (mechanism 2) running **after** merge; if it fails on `main`, the failed run becomes visible on the next merge attempt because `strict=true` requires the PR's branch to be up to date with `main`. Acknowledged limitation: required-context names are matched as display strings — if anyone renames the workflow's `name:` fields, protection silently stops gating. One-line check in CLAUDE.md §5 is a future cleanup, not in scope here.
+
+The general lesson: **any Action that depends on a repo-level toggle must set its auto-enable flag, or the job's first step must `gh api` the toggle and fail loudly with remediation steps.** Workflows that look correct on disk but silently depend on settings are the worst kind of CI bug — they pass review and fail on someone else's machine.

--- a/docs/learning/index.md
+++ b/docs/learning/index.md
@@ -5,4 +5,5 @@ Notes from mistakes that cost time. See CLAUDE.md §8 for the policy.
 Format: `- [yyyy-mm-dd-slug.md](yyyy-mm-dd-slug.md) — <context>. <solution>.`
 
 <!-- entries below, newest first -->
+- [2026-05-03-pages-bootstrap.md](2026-05-03-pages-bootstrap.md) — `actions/configure-pages@v5` defaults to `enablement: false`; three red `main` runs landed before the failure was diagnosed because the workflow file gives no hint a repo setting is missing. Set `enablement: true`, pin actions to commit SHAs, add post-deploy asset+freshness check, and gate `main` with branch protection on `ci / GUT (unit + integration)`.
 - [2026-05-03-gh-identity-lubobill1990.md](2026-05-03-gh-identity-lubobill1990.md) — gh CLI had two accounts active and defaulted to the wrong one for repo-owner ops. Use a process-scoped `GH_TOKEN` for `lubobill1990` and act autonomously for any GitHub operation in this repo.


### PR DESCRIPTION
Closes #39

## What

Make the web deploy self-healing and add a real post-deploy verification step.

- \`actions/configure-pages\` pinned to \`983d7736\` (was \`@v5\`) with \`enablement: true\` so a fresh fork bootstraps Pages instead of failing silently.
- \`actions/deploy-pages\` pinned to \`d6db9016\` (was \`@v4\`).
- New "Inject build marker" step embeds \`<meta name="build-sha" content="\${{ github.sha }}">\` into the exported \`index.html\` before upload.
- New "Post-deploy verification" step retries 12×10s checking the asset triplet returns 200 AND the served HTML carries this run's SHA — catches both partial-asset deploys and stale CDN caching.

## Branch protection (post-merge step)

Run after this PR merges (not a tracked file — applied via \`gh api\`):

\`\`\`bash
gh api -X PUT repos/lubobill1990/little-games/branches/main/protection \
  -F "required_status_checks[strict]=true" \
  -F "required_status_checks[contexts][]=ci / GUT (unit + integration)" \
  -F "enforce_admins=false" \
  -F "required_pull_request_reviews=" \
  -F "restrictions="
\`\`\`

Only the \`test\` job is required: \`export-web\` is gated to \`main\` push and never runs on PRs, so requiring it would block all merges. Deploy correctness is enforced by the post-deploy verification on the \`main\` push instead.

## How tested

- Local GUT suite green (443/443) — no game-code touched.
- The post-deploy step itself can only be exercised on \`main\` after merge; if marker injection or the curl loop is wrong, that push goes red and the site stays up because the deploy step is unchanged.
- Acceptance #1 verification (configure-pages source inspection) documented in \`docs/learning/2026-05-03-pages-bootstrap.md\`.

## Estimated effective diff

50 lines (total 77, excluded 27).