### PR TITLE
chore: track .claude/skills/ source under git

### DIFF
--- a/.claude/skills/gh-nit-cleanup/SKILL.md
+++ b/.claude/skills/gh-nit-cleanup/SKILL.md
@@ -1,0 +1,385 @@
+---
+name: gh-nit-cleanup
+description: Process a Backlog `nit-cleanup` rolling-issue end-to-end — read every finding (issue body + every comment), classify each as nit / minor / major / spinoff-worthy, fix everything that's safely inline-fixable in one PR, spin the rest into individual issues with PRD + Dev plan, and post a transparent decision log on the rolling issue so the reviewer can see the scope without re-deriving it.
+---
+
+# gh-nit-cleanup
+
+Specialist sibling of `implement-task`. **Per `/loop` tick, work at most one nit-cleanup issue.** This skill exists because the rolling cleanup issues bundled by `gh-pr-review` accumulate **dozens** of findings across multiple PRs — too many for `implement-task`'s single-PR cadence to digest, and too varied (literal one-liners next to architectural refactors) for one batch decision.
+
+The skill is opinionated on **scope discipline**: do the trivia in this PR, but never let one cleanup PR balloon into a refactor of the whole codebase. Anything that needs design judgement gets its own issue with a real PRD.
+
+## Identity
+
+Same contract as `implement-task` (see `.claude/skills/implement-task/SKILL.md` § Identity). Pin to `weavejamtom` via process-scoped `GH_TOKEN`:
+
+```bash
+export GH_TOKEN=$(gh auth token --user weavejamtom 2>/dev/null)
+[ -n "$GH_TOKEN" ] || { echo "weavejamtom not in gh keyring; run: gh auth login --user weavejamtom"; exit 1; }
+[ "$(gh api user --jq .login)" = "weavejamtom" ] || { echo "GH_TOKEN didn't resolve to weavejamtom"; exit 1; }
+```
+
+Per-worktree git config (in §3 below):
+
+```bash
+git -C "$WT" config user.name "Tom Lei"
+git -C "$WT" config user.email "tom@weavejam.com"
+git -C "$WT" config --local credential.https://github.com.helper '!gh auth git-credential'
+```
+
+Never `gh auth switch`. Never modify global git config.
+
+## Inputs (hardcoded)
+
+- Repo: `lubobill1990/little-games`
+- Project: user `lubobill1990`, project number `5`, project node id `PVT_kwHOAAnKBM4BWZYr`
+- Status field id: `PVTSSF_lAHOAAnKBM4BWZYrzhRuER4` — Backlog `c159f539` · InProgress `52594841` · InReview `43a760f0` · ChangesRequested `4c71b2f8` · Done `bb829f92`
+- Worktree root: `.implement-task-worktrees/` (shared with `implement-task`; one subdir per task: `task-<n>`).
+- State file: `.implement-task-state.json` at repo root (shared with `implement-task` so a tick can see what other implementers are mid-flight). This skill writes to a new top-level key:
+
+```json
+{
+  "active": { … },                       // owned by implement-task; we read but don't write
+  "pending_review": { … },                // owned by implement-task; we read but don't write
+  "blocked_global": { … },                // owned by implement-task
+  "nit_active": {                         // owned by gh-nit-cleanup
+    "<issue_number>": {
+      "worktree": ".implement-task-worktrees/task-<n>",
+      "branch": "task/<n>-nit-cleanup",
+      "started_at": "<iso>",
+      "last_step": "classified|fixing|pushed|ci_waiting|ci_red_fixing"
+    }
+  },
+  "nit_pending_review": {                 // mirrors implement-task's pending_review for our PRs
+    "issue": <n>, "pr": <pr>, "moved_to_in_review_at": "<iso>"
+  }
+}
+```
+
+Concurrency note: `nit_active.<n>` and `active.<n>` are disjoint by issue number. The shared worktree root is fine because each task gets its own subdir; `git worktree add` would refuse a collision anyway.
+
+## Per-tick priority order
+
+Each `/loop` tick walks this list and stops at the first match.
+
+1. **§1a Resume mid-flight nit work** — `nit_active` has an entry. Healthy worktree → resume from `last_step`. Crashed mid-CI → re-enter §6 (wait for CI).
+2. **§1b Wait for our previous nit PR to clear In review** — `nit_pending_review` is set. Block (60s polling, 5 × 10-min wrappers like `implement-task` §1d) until the linked issue's status leaves `In review`. Then exit the tick.
+3. **§2 Pick a Backlog nit-cleanup issue.** Filter Project #5 to:
+   - `status == "Backlog"` AND
+   - labels include `nit-cleanup` AND
+   - issue is open AND
+   - no `weavejamtom` "🧹 Claimed by gh-nit-cleanup at …" sentinel newer than 4 hours (cross-skill claim race guard).
+
+   Sort by issue number ascending. Take the first.
+
+If nothing claimable: post once-per-day to issue #9 (per `implement-task` §10 dedupe) with reason `no_nit_cleanup_claimable` and exit.
+
+## Procedure
+
+### 1. Sanity (mirrors implement-task §0)
+
+```bash
+git worktree prune
+ls .implement-task-worktrees/ 2>/dev/null | while read d; do
+  git worktree list --porcelain | grep -q ".implement-task-worktrees/$d" \
+    || rm -rf ".implement-task-worktrees/$d"
+done
+```
+
+Then run §Identity check; on failure, jump to `implement-task` §10's auth-wrong path (post to #9, stop).
+
+### 2. Claim and bootstrap
+
+For chosen issue `<N>`:
+
+```bash
+TITLE=$(gh issue view <N> --repo lubobill1990/little-games --json title --jq .title)
+WT=".implement-task-worktrees/task-<N>"
+BRANCH="task/<N>-nit-cleanup"
+
+gh issue comment <N> --repo lubobill1990/little-games \
+  --body "🧹 Claimed by gh-nit-cleanup skill at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+git fetch --prune origin
+git rev-parse --verify --quiet origin/main >/dev/null \
+  || { echo "origin/main missing"; exit 1; }
+git worktree add -b "$BRANCH" "$WT" origin/main
+touch "$WT/.lock"
+
+git -C "$WT" config user.name "Tom Lei"
+git -C "$WT" config user.email "tom@weavejam.com"
+git -C "$WT" config --local credential.https://github.com.helper '!gh auth git-credential'
+
+scripts/board.sh <N> InProgress
+```
+
+Update state: `nit_active.<N> = { worktree, branch, started_at, last_step: "classified" }` (we'll move to `fixing` once classification is done; "classified" is the sentinel that bootstrap completed).
+
+### 3. Read EVERY finding (body + every comment)
+
+Pull both surfaces. The issue body holds the original cleanup-batch findings; every PR review run that produced more nits posted them as comments via `gh-pr-review` §5b or `implement-task` §11e.
+
+```bash
+gh issue view <N> --repo lubobill1990/little-games --json body --jq .body > /tmp/nit-<N>-body.md
+gh api repos/lubobill1990/little-games/issues/<N>/comments \
+  --jq '[.[] | select(.user.login == "weavejamtom" or .user.login == "lubobill1990") | .body]' \
+  > /tmp/nit-<N>-comments.json
+```
+
+Parse out individual findings. The standard format from both review skills:
+
+```
+- [ ] **<file>:<line>** (<severity>) — <title>
+  <body>
+  [permalink](…)
+```
+
+Don't try to be clever about file:line extraction — the structure is rigid. If a comment has the line `### From PR #N @ <sha> — <date>` followed by bullets, treat each bullet as one finding. Skip findings whose checkbox is already `[x]` (someone fixed it earlier).
+
+### 4. Classify
+
+For each finding, assign exactly one bucket:
+
+| Bucket | Definition | Action |
+|---|---|---|
+| **trivial** | Single-token rename, dead const/var/import removal, comment fix, typo, missing type annotation, missing keycode in a list, single-line constant tweak. < 5 lines, no new logic, no new tests. | Fix inline in this PR. |
+| **small-behavior** | Bounded behavior fix in one file: small RNG-order change, missing guard, missing reset, off-by-one, single test added that exercises an existing branch, comment-vs-code mismatch corrected. < 30 lines, < 3 files, no new public API. | Fix inline in this PR. |
+| **spinoff** | Anything that needs design judgement OR touches multiple games consistently OR introduces new public API OR is a refactor across > 3 files OR the reviewer's body itself uses words like "either / or", "design choice", "follow-up adjacent". | Spin out as its own issue with PRD + Dev plan (see §5). Do **not** fix inline. |
+
+When unsure, default to **spinoff** — it is cheaper to defer and design properly than to land a half-baked refactor that the next review round will flag again.
+
+### 5. Spin out the spinoffs (one issue each)
+
+For each spinoff finding, create an issue:
+
+```bash
+gh issue create --repo lubobill1990/little-games \
+  --title "<area>: <short imperative title>" \
+  --label "type:task,area:<game-or-infra>" \
+  --body "<body — see template below>"
+```
+
+**Body template** (PRD + Dev plan, terse — match `CLAUDE.md` §5 brevity):
+
+```markdown
+Spun off from #<N> (PR #<source-pr> batch).
+
+## PRD
+
+**Problem.** <2–4 sentences from the finding body, paraphrased — not pasted, since the source has prose-y "I think" framings that don't belong in an acceptance-criteria spec.>
+
+**Goal.** <One sentence describing the desired end-state.>
+
+**Scope.** <Files / modules touched.>
+
+**Non-goals.** <What this issue is NOT doing — usually adjacent things the reviewer also flagged.>
+
+**Acceptance.** <Concrete grep-able / runnable check.>
+
+## Dev plan
+
+**Files.** ~<n> files, ~<n> lines.
+
+**Sequence.** <Bullet list, ideally one commit per logical step.>
+
+**Test strategy.** <New tests? Reuse existing? Manual smoke?>
+
+**Risks.** <Known footguns. If the finding had multiple alternatives, list which one this issue commits to and why.>
+```
+
+Add the new issue to Project #5 in Backlog (it'll get refined to Ready + claimed by `implement-task` later):
+
+```bash
+NEW_ID=$(gh issue view <new-issue-num> --repo lubobill1990/little-games --json id --jq .id)
+gh project item-add 5 --owner lubobill1990 --url <new-issue-url>  # easier than the GraphQL dance
+```
+
+(The card lands in Backlog by default. No status flip needed.)
+
+Capture each created issue's number for the decision log in §7.
+
+### 6. Fix the trivial + small-behavior findings inline
+
+Update state: `last_step: "fixing"`.
+
+Implement using `Read` / `Edit` / `Write` against `$WT/`. Group by area (per-game or per-file) for cohesive commits:
+
+```bash
+git -C "$WT" add <files>
+git -C "$WT" commit -m "<conventional type>: <area> — <one-line subject>
+
+Refs #<N> (<source PR list, e.g. PRs #41, #46>)"
+```
+
+Conventional types per `CLAUDE.md` §5. Suggested commit-grouping heuristic: one commit per (area, severity) — e.g. `chore(invaders): drop dead Self consts and unused palette colors`, `fix(2048): cap _settings to one lookup`, `test(snake): cover board-full game_over branch`.
+
+Run GUT after every meaningful chunk to catch regressions early:
+
+```bash
+godot --headless --path "$WT/godot" -s addons/gut/gut_cmdln.gd \
+  -gconfig=res://.gutconfig.json
+```
+
+Fix red tests in the same chunk before the next chunk. Up to 3 fix iterations per chunk; if still red, comment on the **task issue** with the failing test, leave the worktree intact, and exit (next tick's §1a resumes).
+
+**Hard constraints.**
+- Never amend a pushed commit. Never `--force` push. Never `--no-verify`.
+- Per-game `core/` must not import `Node` or call OS/Engine APIs (`CLAUDE.md` §5).
+- GDScript statically typed.
+- **No scope creep.** If during a fix you spot something the reviewer missed, write it down for the *next* nit-cleanup batch — do not fold it in here.
+
+### 7. Decision log on the cleanup issue
+
+Before pushing, post **one comment** on the cleanup issue (`<N>`) summarizing what was done and what wasn't. Reviewer reads this first, so it sets scope expectations.
+
+```bash
+gh issue comment <N> --repo lubobill1990/little-games --body "$(cat <<EOF
+🧹 **gh-nit-cleanup pass — decision log**
+
+Read <K> findings across the issue body and <M> comments.
+
+### Fixed inline in PR #<PR>
+
+**<area-1> (<count>):**
+- <file>:<line> — <one-line summary>
+- ...
+
+**<area-2> (<count>):**
+- ...
+
+### Spun out as separate issues (with PRD + Dev plan)
+
+Bigger than nit scope or needed design judgement:
+
+- #<spinoff-1> — <one-line title>
+- #<spinoff-2> — <one-line title>
+- ...
+
+### Out of scope this pass — reasoning
+
+- <finding> — <why deferred — e.g. "needs editor re-save", "blocked on #<other>", "duplicates already-open #<other>">
+- ...
+
+The issue stays open until all checkboxes are resolved (either by this PR landing, by the spun-out issues being completed, or by an explicit decision to drop). Next \`/gh-nit-cleanup\` tick will not re-claim while \`In progress\`.
+EOF
+)"
+```
+
+The decision log is the contract with the reviewer: it tells them what to expect in the diff and what to NOT expect. Without it, the reviewer re-derives "what did the implementer choose to fix vs. defer" from scratch every pass, which is exactly the tax this skill is meant to eliminate.
+
+### 8. Push and open PR
+
+```bash
+git -C "$WT" push -u origin "$BRANCH"
+```
+
+Update `last_step: "pushed"`.
+
+Compute effective diff size (mirrors `implement-task` §8 / `gh-pr-review` §4b rule 5):
+
+```bash
+TOTAL=$(git -C "$WT" diff --shortstat origin/main \
+  | grep -oE '[0-9]+ insertion|[0-9]+ deletion' \
+  | grep -oE '[0-9]+' | paste -sd+ - | bc)
+TOTAL=${TOTAL:-0}
+EXCLUDED=$(git -C "$WT" diff --numstat origin/main \
+  | awk '$3 ~ /^(godot\/)?tests\/|^(godot\/)?assets\/|^docs\/|\.import$|\.translation$|\.lock$|^[^/]+\.md$|^package-lock\.json$|^pnpm-lock\.yaml$/ \
+         {sum += $1 + $2} END {print sum+0}')
+EFFECTIVE=$((TOTAL - EXCLUDED))
+```
+
+Build PR body. The cleanup PR is unusual: many small unrelated fixes, but each is justified by the decision log on the issue, so the body is short.
+
+```markdown
+Refs #<N>
+
+Cleanup pass on the rolling nit-cleanup issue. Decision log + per-finding scope rationale lives on the issue: <link to the §7 comment>.
+
+## Summary
+- <K> trivial / small-behavior findings fixed inline (<count> commits, grouped by area).
+- <S> larger findings spun out as #<a>, #<b>, … with PRD + Dev plan.
+
+## How tested
+- GUT suite green locally.
+- <any specific test added — name it>.
+
+## Estimated effective diff
+<EFFECTIVE> lines (total <TOTAL>, excluded <EXCLUDED>).
+```
+
+If `EFFECTIVE > 400`: append the same `large-pr-ok` warning as `implement-task` §8. Cleanup PRs **often** exceed 400 effective lines; that's normal. Comment on the cleanup issue (NOT the PR — that channel belongs to `gh-pr-review`):
+
+> ⚠️ This cleanup PR is `<EFFECTIVE>` effective lines (>400). Apply `large-pr-ok` to allow auto-merge, or split the trivial fixes by area into multiple PRs and I'll redo it on the next pass.
+
+Open the PR:
+
+```bash
+gh pr create --repo lubobill1990/little-games \
+  --base main --head "$BRANCH" \
+  --title "chore: nit cleanup batch — <area summary>" \
+  --body "$PR_BODY"
+```
+
+Capture `<PR>`. Run §9 (wait for CI).
+
+### 9. Wait for CI
+
+Reuse `implement-task` §12 verbatim — the wait-for-CI loop is identity-agnostic. On red, fix locally (consult `docs/lessons/index.md` first) up to 3 attempts; on green, proceed to §10. On timeout / no-checks / 3-attempt red, escalate to issue #9 same as `implement-task` §12 step 4. The §12 lesson-recording machinery (step 5) also applies — if CI took ≥ 2 fix rounds to green, write `docs/lessons/ci-<slug>.md` + index entry.
+
+### 10. Move card and clean up
+
+```bash
+scripts/board.sh <N> InReview
+
+rm -f "$WT/.lock"
+git worktree remove --force "$WT"
+```
+
+Drop `nit_active.<N>`. Set `nit_pending_review = { issue: <N>, pr: <PR>, moved_to_in_review_at: <iso> }` so the next tick's §1b gates on review completion.
+
+The cleanup issue **stays open**. It moves from `In review` (during PR review) to either:
+- `Done` if the PR merge auto-closes it via the `Closes #<N>` keyword (we don't use that — see below); OR
+- back to `Backlog` if checkboxes remain after this PR lands.
+
+The cleanup issue is intentionally a **rolling** container — `gh-pr-review` and `implement-task` keep appending nits to it. So we **don't** put `Closes #<N>` in the PR body; merging the PR shouldn't close the rolling issue. The PR refs the issue but doesn't close it. The issue's lifecycle is governed by manual close ("all boxes done, drop") or by `gh-pr-review` opening a fresh batch issue when this one moves out of Backlog (the existing convention from `gh-pr-review` SKILL.md §5b).
+
+Since we move the rolling issue to `In review` while the PR is open, `gh-pr-review` will see `status != Backlog` and open a new batch issue on its next nit-emitting run — the rolling pipeline keeps working.
+
+After the PR merges:
+- `gh-pr-review`'s post-merge plumbing handles its side.
+- `nit_pending_review` clears on the next tick (§1b unblocks once the issue leaves `In review`).
+- The cleanup issue's checkboxes for items we fixed are still `[ ]`; check them off as a follow-up commit on the issue body, or leave for the next tick / human to tidy. Recommended: check them off in §7's decision-log comment so the next reader sees status without scrolling.
+
+Print one-line summary:
+
+```
+gh-nit-cleanup #<N> "<title>" → PR #<PR> opened (<K> fixed inline, <S> spun out, eff=<n>).
+```
+
+## Style guardrails
+
+- All `gh` calls inherit the active account (verified `weavejamtom` at §1).
+- Never push `--force`, never `--amend` after push, never `--no-verify`.
+- Don't comment on PRs from this skill — `gh-pr-review` owns that channel. Comments go on the cleanup issue or on spun-out issues.
+- Don't move cards beyond `InReview` — `gh-pr-review` moves to Done after merge.
+- Never modify global git config.
+- Per run, one cleanup issue. Strict.
+- Always use `git -C "$WT"` and `--path "$WT/godot"`. Never `cd`.
+- **Never** write `Closes #<N>` in the cleanup PR body — the issue is rolling, not closeable by a single PR.
+- **Always** post the decision log (§7) BEFORE opening the PR, so the PR body can link to it.
+
+## Concurrency notes
+
+- Coexists with `implement-task`: shared worktree root + state file, disjoint top-level state keys (`active` vs `nit_active`), disjoint claim-sentinel emoji (`🔧` vs `🧹`).
+- Two `gh-nit-cleanup` instances on the same machine: per-issue worktree dir + `.lock` + claim sentinel handle the race; second instance will find no claimable issue (the first one's claim sentinel is < 4h old) and exit silently.
+- Cross-machine: GitHub state (claim comment, board status, branch on origin) is the source of truth.
+
+## When to invoke this skill vs. `implement-task`
+
+| Situation | Skill |
+|---|---|
+| Backlog issue is a regular `type:task` with PRD + Dev plan, single feature scope | `implement-task` |
+| Backlog issue is the rolling `nit-cleanup` with mixed-severity findings across many PRs | `gh-nit-cleanup` |
+| Backlog issue is a spinoff *from* `gh-nit-cleanup` (now has its own PRD + Dev plan) | `implement-task` |
+
+If the user invokes `/gh-nit-cleanup` while a different skill's worktree is mid-flight (`implement-task`'s `active` non-empty), `implement-task` §1a's "resume in-progress beats new claim" still applies for the *user's intent* — surface the conflict to the user (via `AskUserQuestion`) before clobbering. The state file's separate top-level keys mean both skills can coexist, but the human typically wants serialized work.

--- a/.claude/skills/gh-pr-review/SKILL.md
+++ b/.claude/skills/gh-pr-review/SKILL.md
@@ -1,0 +1,553 @@
+---
+name: gh-pr-review
+description: Scan Project #5 for issues in "In review", review their linked PRs (incrementally per commit SHA), file inline/general comments by severity, request changes on blocker/major findings, and spin off non-blocking improvements as prioritized backlog issues. TRIGGER on `/gh-pr-review` or via `/loop 1m /gh-pr-review` — §0 blocks on a watch script until real work arrives, so tight loops cost no tokens on empty ticks.
+---
+
+# gh-pr-review
+
+You are acting as the **PR reviewer** for `lubobill1990/little-games`. Be strict, terse, and actionable. Honor the brevity contract in `CLAUDE.md`.
+
+## Identity
+
+**All GitHub operations in this skill MUST run as the `lubobill1990` user account.** This includes review submissions, approvals, merges, comments, issue creation, and project mutations. Do not switch accounts mid-run.
+
+The companion `implement-task` skill runs as a different account (`weavejamtom`) — that separation is what gives "review" meaningful authority over "implement". A PR authored by `weavejamtom` and approved/merged by `lubobill1990` reflects two distinct identities.
+
+Before starting any run, pin this skill's identity to `lubobill1990` via the `GH_TOKEN` env var. **Do not use `gh auth switch`** — it mutates the user-level `~/.config/gh/hosts.yml`, which collides with the `implement-task` skill running on the same machine. `GH_TOKEN` is process-scoped and overrides whatever account is "active", giving us race-free isolation.
+
+```bash
+export GH_TOKEN=$(gh auth token --user lubobill1990 2>/dev/null)
+[ -n "$GH_TOKEN" ] || { echo "lubobill1990 not in gh keyring; run: gh auth login --user lubobill1990"; gh auth status; exit 1; }
+ACTIVE=$(gh api user --jq .login)
+[ "$ACTIVE" = "lubobill1990" ] || { echo "GH_TOKEN didn't resolve to lubobill1990 (got $ACTIVE)"; exit 1; }
+```
+
+`GH_TOKEN` lives only in the current Bash process — every `/loop` tick re-runs §0, so the export is fresh each time. All `gh api` / `gh pr` / `gh issue` / `gh project` calls in §1–§6 inherit it automatically.
+
+If you need git over https in this skill (e.g., a worktree push in §7), wire it to the same token so it doesn't fall back to whatever credential the OS keychain has cached:
+
+```bash
+git -C "$WT" config --local credential.https://github.com.helper '!gh auth git-credential'
+# `gh auth git-credential` inherits GH_TOKEN from env, so push uses lubobill1990's token.
+```
+
+## Inputs (hardcoded for this repo)
+
+- Repo: `lubobill1990/little-games`
+- Project: user `lubobill1990`, project number `5`, id `PVT_kwHOAAnKBM4BWZYrzhRuERw` style — query fresh each run; cache only what's below.
+- Status field id: `PVTSSF_lAHOAAnKBM4BWZYrzhRuER4`
+  - Backlog `c159f539` · Ready `391bc048` · In progress `52594841` · In review `43a760f0` · Changes requested `4c71b2f8` · Done `bb829f92`
+- Priority field id: `PVTSSF_lAHOAAnKBM4BWZYrzhRuEWM`
+  - P0 `79628723` · P1 `0a877460` · P2 `da944a9c`
+- Project node id: `PVT_kwHOAAnKBM4BWZYr`
+- State file: `.gh-pr-review-state.json` at repo root (gitignored). Kept outside `.claude/` so writes don't trigger settings-dir approval prompts. Schema: `{ "<pr_number>": { "last_reviewed_sha": "<sha>", "last_reviewed_at": "<iso>" } }`.
+- Worktree root: `.pr-review-worktrees/` (gitignored). One subdir per PR (`pr-<n>`). Used **only when local investigation is needed** (see §7).
+
+## Procedure
+
+### 0. Wait for review work (event-driven gate)
+
+Time-based `/loop` ticks are wasteful when the queue is empty. Before doing anything else, block on the watch script until at least one PR in `In review` has a SHA that's not in `.gh-pr-review-state.json`. The script polls every 60s via a single GraphQL call (board + linked PR + headRefOid in one hit) and only writes JSON to stdout when there's actual work (reuses the same `.gh-pr-review-state.json` as §2).
+
+**Important — Bash tool timeout caveat.** The Claude Code `Bash` tool caps at `timeout=600000` (10 min); the script itself has no timeout. Always invoke it with the full 10-min budget. If the budget expires before work arrives, stdout will be empty — re-invoke up to 5 times in a row (≈ 50 min total wait per skill run) before giving up so the `/loop` tick can recycle:
+
+```bash
+# Bash tool call — set timeout=600000 (the max).
+WORK=""
+for attempt in 1 2 3 4 5; do
+  WORK=$(uv run --quiet --script .claude/skills/gh-pr-review/wait-for-review-queue.py)
+  RC=$?
+  if [ $RC -eq 0 ] && [ -n "$WORK" ]; then
+    break              # got JSON, proceed
+  fi
+  if [ $RC -ne 0 ] && [ $RC -ne 124 ] && [ $RC -ne 143 ]; then
+    # Real error from the script (gh failure, etc.) — abort
+    echo "watch script exited $RC; aborting this run"
+    exit $RC
+  fi
+  # Otherwise: tool-level timeout (empty stdout). Loop and re-poll.
+done
+if [ -z "$WORK" ]; then
+  echo "no review work after 5×10min waits; exiting cleanly so /loop can recycle"
+  exit 0
+fi
+echo "$WORK"  # JSON: {"prs":[{"issue":N,"pr":N,"sha":"..."}, ...]}
+```
+
+Driven by `/loop 1m /gh-pr-review`, this means: empty queue → skill burns ~zero tokens for up to 50 min, then the loop respawns it; new card lands → script returns within 30s and review proceeds.
+
+The `WORK` JSON is informational only; §1 still does its own authoritative scan (the queue can shift between the watch returning and the skill reaching §1).
+
+### 0a. Cleanup stale worktrees
+
+Before anything else:
+
+```bash
+git worktree prune
+# Remove any pr-<n> dirs whose worktree no longer exists
+ls .pr-review-worktrees/ 2>/dev/null | while read d; do
+  git worktree list --porcelain | grep -q ".pr-review-worktrees/$d" || rm -rf ".pr-review-worktrees/$d"
+done
+```
+
+### 1. Find PRs to review
+
+```bash
+gh project item-list 5 --owner lubobill1990 --format json --limit 100
+```
+
+Filter items where `status == "In review"`. For each, resolve the linked PR:
+
+```bash
+gh issue view <issue_number> --repo lubobill1990/little-games --json number,title,projectItems,closedByPullRequestsReferences
+```
+
+If no linked PR, skip and note in summary.
+
+### 2. Skip already-reviewed SHAs
+
+Read `.gh-pr-review-state.json` (create if missing). For each PR:
+
+```bash
+gh pr view <pr> --repo lubobill1990/little-games --json number,headRefOid,title,author,baseRefName,files,commits
+```
+
+If `headRefOid == state[pr].last_reviewed_sha`, skip. Otherwise:
+- If state has a prior sha, do an **incremental review** (diff `prior_sha..headRefOid`).
+- Else full review of `gh pr diff <pr>`.
+
+### 3. Run the review
+
+Delegate to the built-in `review` skill OR perform the review yourself, but **the output MUST be a JSON array of findings** with this shape:
+
+```json
+[
+  {
+    "severity": "blocker" | "major" | "minor" | "nit" | "followup",
+    "file": "godot/scripts/foo.gd",
+    "line": 42,
+    "end_line": 47,
+    "title": "short one-liner",
+    "body": "what's wrong + suggested fix (markdown allowed)",
+    "suggestion": "optional ```suggestion block content"
+  }
+]
+```
+
+Severity rubric:
+- **blocker** — bug, data loss, broken build, security, violates `CLAUDE.md` hard rule (e.g., `core/` importing `Node`).
+- **major** — missing tests for new logic, untyped GDScript, broken contract, perf regression in hot path.
+- **minor** — naming, dead code, small DRY opportunity, missing edge case test.
+- **nit** — style, comment polish, doc typo.
+- **followup** — out of scope for this PR; should become a backlog issue, not a PR comment.
+
+Hard caps:
+- ≤ 15 comments per PR. If more, keep top 15 by severity, fold the rest into a single summary comment listing them.
+- blocker/major MUST have file + line.
+
+### 4. Post comments
+
+For inline comments (any finding with `file` + `line`), use the GitHub review API in one batch:
+
+```bash
+gh api -X POST repos/lubobill1990/little-games/pulls/<pr>/reviews \
+  -f event="<EVENT>" \
+  -f body="<overall summary>" \
+  -F commit_id="<headRefOid>" \
+  -f "comments[][path]=..." -F "comments[][line]=..." -f "comments[][body]=..."
+```
+
+Where `<EVENT>`:
+- Any `blocker` or `major` finding → `REQUEST_CHANGES` (then §4 plumbing: move issue to `Changes requested`, leave findings on PR for the author to address).
+- Otherwise (only `minor` / `nit` / `followup`) → **don't post the inline comments here.** Skip directly to §4d, which rolls the non-blocking findings into the cleanup issue and auto-merges. Posting inline comments alongside an auto-merge produces dangling unresolved threads on the merged PR.
+
+The "post inline comments + COMMENT event" path only runs implicitly inside §4d-step-1 when §4d has decided to merge — and even then, the comments are batched into the rolling cleanup issue's body rather than the PR (the PR is about to be merged; conversation belongs in the backlog issue).
+
+For nits without a clear line on a `REQUEST_CHANGES` review, batch into the review `body` under a `### Nits` section.
+
+For findings with a `suggestion`, the comment body should end with:
+
+````
+```suggestion
+<suggestion>
+```
+````
+
+**After posting a `REQUEST_CHANGES` review:** move the linked tracking issue (from §1) to `Changes requested` so the board reflects "author needs to iterate" rather than "still under review":
+
+```bash
+scripts/board.sh <linked_issue> ChangesRequested
+```
+
+This is also a CLAUDE.md hard rule (§5 Process #5). The author / `implement-task` skill is responsible for moving it back to `InReview` on their next push (and only when CI is green) — this skill never moves a `Changes requested` card forward.
+
+**On a `REQUEST_CHANGES` review, do NOT touch the rolling cleanup issue.** §5b is *only* the no-finding-at-all backlink path now (the rolling-cleanup write is handled by §4d for the auto-merge case). For PRs that need changes, leave `minor` / `nit` findings as inline PR comments — `implement-task` will pick them up while fixing the blockers and decide what to roll into `Nit & minor cleanup` (see `implement-task` SKILL.md §11 for the contract).
+
+### 4b. Auto-approve and auto-merge clean PRs (no findings at all)
+
+If the review produced **zero findings of any severity** (no blocker / major / minor / nit / followup), the PR is eligible for auto-merge via this section.
+
+If the review produced **only `minor` / `nit` / `followup` findings (no blocker / no major)**, the PR is still eligible for auto-merge — but goes through **§4d** instead of §4b. §4d batches the non-blocking findings into the rolling cleanup issue (and spins off `followup` items per §5) before merging.
+
+If **any gate below fails** for an otherwise-eligible PR, post a plain `event=COMMENT` review with `body="No findings at <sha>."` (§4b case) or the §4d "rolled K findings into #N" message (§4d case) and STOP — do not merge.
+
+**Gates** (all must pass):
+
+1. PR is not a draft: `gh pr view <pr> --json isDraft --jq .isDraft` == `false`
+2. CI is green:
+   ```bash
+   gh pr checks <pr> --repo lubobill1990/little-games
+   ```
+   All required checks `pass`. No `pending`, no `fail`.
+3. No unresolved review threads from other reviewers:
+   ```bash
+   gh api graphql -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){pullRequest(number:$n){reviewThreads(first:50){nodes{isResolved}}}}}' \
+     -F o=lubobill1990 -F r=little-games -F n=<pr> --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false)'
+   ```
+   Must be empty.
+4. PR author MUST be `weavejamtom` (the implement-task skill's identity). PRs from any other account — including `lubobill1990` herself or external contributors — always require human merge:
+   ```bash
+   gh pr view <pr> --json author --jq .author.login
+   # Must equal: weavejamtom
+   ```
+5. The linked issue (from §1) is in Status=`In review`. If it's still `In progress`, author isn't done yet — skip merge.
+
+**Action when all gates pass:**
+
+```bash
+# Approve via review API
+gh api -X POST repos/lubobill1990/little-games/pulls/<pr>/reviews \
+  -f event="APPROVE" \
+  -f body="Auto-approved by gh-pr-review skill: no findings at <sha>, CI green, all gates passed." \
+  -F commit_id="<headRefOid>"
+
+# Squash merge (preserves clean main history per CLAUDE.md brevity contract)
+gh pr merge <pr> --repo lubobill1990/little-games --squash --delete-branch
+```
+
+After merge:
+- Move the linked issue to Done: `scripts/board.sh <issue> Done`
+- Update state file with the merged sha so a re-run doesn't try again
+- Note in summary: `#<pr> "<title>" → AUTO-MERGED (no findings)`
+
+**Hard limits on auto-merge:**
+
+- Never use `--admin` to bypass branch protection.
+- Never auto-merge if any gate is uncertain (e.g., GraphQL call errored) — fail closed, post the comment, stop.
+- Never auto-merge a PR authored by anyone other than `weavejamtom`. PRs by `lubobill1990` herself or external contributors are out of scope for auto-merge — comment "No findings at <sha>" and stop.
+- Per run, auto-merge **at most 1 PR**, even if multiple are eligible. Forces human to notice the cadence.
+
+### 4c. Human-override merge
+
+When the user explicitly tells you to merge a PR despite a §4b gate failing (e.g., findings rolled into nit-cleanup, author isn't `weavejamtom`), this is a **human override** — proceed, but follow the same post-merge plumbing as §4b so the audit trail stays consistent.
+
+Pre-flight (always check, even on override):
+
+1. CI must still be green (`gh pr checks <pr>`). Override does not bypass red CI.
+2. `GH_TOKEN` MUST still resolve to `lubobill1990` (verify with `gh api user --jq .login`). Since §0 exported it once per process, this should be a no-op; if it's empty or wrong, re-run the §Identity export block. Never approve / merge a PR while authenticated as its author — GitHub will reject self-approval and the audit trail will be muddled.
+3. Any `blocker` or `major` finding still in play → STOP and report. Override is for non-blocking findings only.
+
+Action:
+
+```bash
+# Approve, citing the override reason
+gh api -X POST repos/lubobill1990/little-games/pulls/<pr>/reviews \
+  -f event="APPROVE" \
+  -F commit_id="<headRefOid>" \
+  -f body="Approved by gh-pr-review skill (human override of §4b: <reason>)."
+
+# Squash merge
+gh pr merge <pr> --repo lubobill1990/little-games --squash --delete-branch
+
+# Post-merge plumbing (same as §4b)
+scripts/board.sh <linked_issue> Done
+# Update .gh-pr-review-state.json with the merged sha
+```
+
+Note in summary: `#<pr> "<title>" → MERGED (human override: <reason>)`.
+
+### 4d. Auto-merge with non-blocking findings (minor/nit/followup → cleanup issue)
+
+Triggered when the review has **no `blocker` and no `major`** but produces ≥ 1 `minor` / `nit` / `followup`. Same gates as §4b (CI green, not draft, no foreign unresolved threads, author=`weavejamtom`, linked issue in `In review`); if any gate fails, fall back to posting a single `event=COMMENT` review with `body="No findings requiring changes at <sha>; gate <which> failed."` and STOP.
+
+**Why this exists.** Posting `minor`/`nit` as inline `COMMENT` review threads on a PR we then auto-merge leaves dangling unresolved threads on the merged PR — noisy and wrong. Per CLAUDE.md brevity contract, non-blocking findings belong in the rolling cleanup backlog issue (§5b's existing pattern), not as merged-PR review threads. §4d enforces that flow automatically.
+
+**Procedure** (do these in order; STOP and revert via §6 state-file rule if any step fails):
+
+1. **Roll up `minor` / `nit` into the rolling cleanup issue** using §5b's full procedure — find/create the rolling issue, append the batch block, post backlinks on the PR + tracking issue. Capture the `<cleanup_issue_url>` and `<batch_url>` for the approval body.
+
+2. **Spin off `followup` findings as scoped backlog issues** using §5's full procedure. Capture the new issue numbers for the approval body.
+
+3. **Approve via the review API** (no inline comments — those went to the cleanup issue):
+
+   ```bash
+   gh api -X POST repos/lubobill1990/little-games/pulls/<pr>/reviews \
+     -f event="APPROVE" \
+     -F commit_id="<headRefOid>" \
+     -f body="Auto-approved by gh-pr-review skill (§4d): <X> minor/nit rolled into <cleanup_issue_url>; <K> followup(s) spun off as #<n>, #<n>. CI green, all gates passed."
+   ```
+
+4. **Squash merge:**
+
+   ```bash
+   gh pr merge <pr> --repo lubobill1990/little-games --squash --delete-branch
+   ```
+
+5. **Post-merge plumbing** (identical to §4b):
+   - Move the linked issue to Done: `scripts/board.sh <linked_issue> Done`
+   - Update `.gh-pr-review-state.json` with `merged_commit` set to the new merge SHA so a re-run doesn't try again.
+
+6. Note in summary: `#<pr> "<title>" → AUTO-MERGED (§4d): rolled <X> minor/nit into #<n>; spun off <K> followup(s) as #<m>, #<m>`.
+
+**Hard limits (same as §4b):**
+
+- Never `--admin` to bypass branch protection.
+- Never auto-merge if a gate is uncertain — fail closed, post the diagnostic COMMENT review, stop.
+- Never auto-merge a PR by anyone other than `weavejamtom`. External / `lubobill1990`-authored PRs always need human review of whether the cleanup-issue rollup is appropriate.
+- Per run, auto-merge **at most 1 PR** total across §4b and §4d combined (forces human to notice cadence).
+- Never run §4d if any finding is `blocker` or `major` — that path is `REQUEST_CHANGES` per §4, not auto-merge.
+
+**The §4b decision tree summarized:**
+
+```
+findings ─┬─ contains blocker/major ─→ §4: REQUEST_CHANGES + move issue to Changes requested. STOP.
+          ├─ all minor/nit/followup  ─→ §4d: roll into cleanup issue + §5 followup issues + auto-merge.
+          └─ empty                    ─→ §4b: APPROVE + auto-merge.
+```
+
+### 5. Spin off `followup` findings as backlog issues
+
+For each `followup` finding:
+
+1. Create issue:
+   ```bash
+   gh issue create --repo lubobill1990/little-games \
+     --title "<title>" \
+     --label backlog \
+     --body "$(cat <<'EOF'
+   Spun off from PR #<pr> review.
+
+   ## PRD
+   _TBD — move to Ready before implementation._
+
+   ## Dev plan
+   _TBD._
+
+   ## Context
+   <body>
+
+   Source: <permalink to file:line at headRefOid>
+   EOF
+   )"
+   ```
+2. Add to Project #5, set Status=Backlog and Priority:
+   - Decide priority by reading existing backlog priorities:
+     ```bash
+     gh project item-list 5 --owner lubobill1990 --format json --limit 100
+     ```
+     Count current P0/P1/P2 in Backlog. Default to **P2** unless the finding text implies user-facing breakage / security / blocker-adjacent (then **P1**). Never auto-assign **P0** — leave that to the human; if you think it's P0, comment on the new issue saying so and set P1.
+   - Add to project + set fields:
+     ```bash
+     # Add issue to project
+     ITEM_ID=$(gh api graphql -f query='mutation($p:ID!,$c:ID!){addProjectV2ItemById(input:{projectId:$p,contentId:$c}){item{id}}}' -F p=PVT_kwHOAAnKBM4BWZYr -F c=<issue_node_id> --jq '.data.addProjectV2ItemById.item.id')
+
+     # Set Status=Backlog
+     gh api graphql -f query='mutation($p:ID!,$i:ID!,$f:ID!,$o:String!){updateProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,fieldId:$f,value:{singleSelectOptionId:$o}}){projectV2Item{id}}}' \
+       -F p=PVT_kwHOAAnKBM4BWZYr -F i=$ITEM_ID -F f=PVTSSF_lAHOAAnKBM4BWZYrzhRuER4 -F o=c159f539
+
+     # Set Priority (P2 example)
+     gh api graphql -f query='mutation($p:ID!,$i:ID!,$f:ID!,$o:String!){updateProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,fieldId:$f,value:{singleSelectOptionId:$o}}){projectV2Item{id}}}' \
+       -F p=PVT_kwHOAAnKBM4BWZYr -F i=$ITEM_ID -F f=PVTSSF_lAHOAAnKBM4BWZYrzhRuEWM -F o=da944a9c
+     ```
+   - `scripts/board.sh` is also fine for Status if preferred.
+
+### 5b. Roll up `minor` / `nit` findings into the rolling cleanup issue
+
+`minor` and `nit` findings are non-blocking but shouldn't evaporate after the PR closes. They're aggregated into a single rolling **"Nit & minor cleanup"** backlog issue, which a human (or the implement-task skill) periodically picks up.
+
+**When this section runs.** §5b is now invoked exclusively as a sub-procedure of **§4d** (auto-merge with non-blocking findings). The standalone `event=COMMENT` path no longer exists — review event is always `REQUEST_CHANGES` (≥1 blocker/major), `APPROVE` (§4b/§4d), or no review at all (skipped SHA / no findings + gate failure → diagnostic COMMENT). When a `REQUEST_CHANGES` review fires, `minor` / `nit` findings stay inline on the PR (per §4 plumbing) — `implement-task` triages them on the fix pass.
+
+**Rolling rule:** there is at most one *open, still-in-Backlog* cleanup issue at a time, identified by the label `nit-cleanup`. The moment that issue moves out of Backlog (a human/skill takes it → In progress / In review / Done, or it's closed), the next nit findings create a **new** cleanup issue. This way each batch maps to one work session.
+
+**Procedure** — invoked by §4d-step-1 with the list of `minor` / `nit` findings.
+
+1. Find the current rolling issue:
+
+   ```bash
+   # Open issues with label nit-cleanup, then filter to those still in Backlog on Project #5
+   gh issue list --repo lubobill1990/little-games \
+     --label nit-cleanup --state open --json number,title,projectItems --limit 20 \
+     --jq '.[] | select(.projectItems[]? | .status.name == "Backlog") | .number' \
+     | head -1
+   ```
+
+   (If `projectItems` shape differs, fall back to GraphQL using project node id `PVT_kwHOAAnKBM4BWZYr` and status field id `PVTSSF_lAHOAAnKBM4BWZYrzhRuER4` to filter for Backlog.)
+
+2. Build the batch block (one block per PR per run):
+
+   ```markdown
+   ### From PR #<pr> @ <short_sha> — <YYYY-MM-DD>
+
+   - [ ] **<file>:<line>** (<severity>) — <title>
+     <body>
+     [permalink](https://github.com/lubobill1990/little-games/blob/<headRefOid>/<file>#L<line>)
+   - [ ] ... (one bullet per finding)
+   ```
+
+3a. **If a rolling issue exists** (step 1 returned a number): append the batch block as a comment.
+
+   ```bash
+   gh issue comment <existing_issue> --repo lubobill1990/little-games --body "$(cat batch.md)"
+   ```
+
+3b. **If no rolling issue exists**: create one.
+
+   ```bash
+   gh issue create --repo lubobill1990/little-games \
+     --title "Nit & minor cleanup — batch starting <YYYY-MM-DD>" \
+     --label nit-cleanup,backlog \
+     --body "$(cat <<'EOF'
+   Rolling collection of `minor` / `nit` findings spun off by the `gh-pr-review` skill. Pick up when convenient — each checkbox is independent and small.
+
+   ## How this issue works
+
+   - One open `nit-cleanup` issue lives in Backlog at any time.
+   - Each PR review run that produces nits appends a new dated block below.
+   - When this issue moves out of Backlog (someone starts it), the next review run opens a fresh cleanup issue.
+
+   ## PRD
+   _Not applicable — see individual checkboxes._
+
+   ## Dev plan
+   Work through bullets one at a time; small commits, conventional messages (`fix:`, `chore:`, `docs:` …). Close the issue when all boxes are checked OR drop remaining items into a new issue if scope balloons.
+
+   ## Findings
+
+   <batch block from step 2>
+   EOF
+   )"
+   ```
+
+   Then add the new issue to Project #5 with Status=`Backlog`, Priority=`P2` (using the GraphQL mutations from §5). Never escalate a cleanup issue's priority automatically.
+
+4. **Capture the cross-links** so future readers can trace nit → cleanup-issue → batch-comment → PR.
+
+   - For step 3a (appended to existing): grab the new comment's `html_url` from the `gh issue comment` output (or query `gh api repos/.../issues/<n>/comments --jq '.[-1].html_url'`). Call this `<batch_url>`. The `<cleanup_issue_url>` is `https://github.com/lubobill1990/little-games/issues/<existing_issue>`.
+   - For step 3b (newly created): the cleanup issue itself is the batch — `<batch_url>` and `<cleanup_issue_url>` are the same URL returned by `gh issue create`.
+
+5. **Backlink from PR and PR's tracking issue.** Post the same short note to both:
+
+   ```bash
+   NOTE="🧹 Rolled <K> minor/nit finding(s) from this review into the rolling cleanup issue: <cleanup_issue_url> (batch: <batch_url>)."
+
+   # On the PR itself (general issue comment, not a review comment — survives if review is dismissed)
+   gh issue comment <pr> --repo lubobill1990/little-games --body "$NOTE"
+
+   # On the PR's tracking issue (the one in §1 that was in "In review")
+   gh issue comment <linked_issue> --repo lubobill1990/little-games --body "$NOTE"
+   ```
+
+   Skip the second call if there's no linked tracking issue.
+
+6. Note the rolling issue number in the summary line for this PR (`rolled <K> minor/nit into #<n>`).
+
+**What still goes through §5 (separate `followup` issues), not here:**
+
+- Anything tagged `severity: followup` in the JSON (out of scope for the PR, deserves its own scoped issue).
+- Anything that needs a real PRD/Dev plan (a feature, a refactor with design decisions).
+
+**What goes here:**
+
+- Doc typos, naming, dead code, missing edge-case tests, style polish, small DRY ops, comment touch-ups, cross-platform script quirks, etc.
+
+If unsure, prefer the rolling issue — it's cheaper to fold a borderline item in than to spawn a one-line scoped issue.
+
+### 6. Update state and summarize
+
+Write `.gh-pr-review-state.json` with the new `headRefOid` per PR. Then output a single summary block to the user:
+
+```
+Reviewed N PR(s):
+  - #<pr> "<title>" → <EVENT>: <X blocker, Y major, Z minor, W nit>; rolled <Z+W> minor/nit into #<n>; spun off <K> followup(s) as #<n>, #<n>
+Skipped M PR(s) (already reviewed at current SHA):
+  - #<pr>
+No linked PR for: <issue_numbers>
+```
+
+Be terse. No congratulations, no preamble.
+
+## Style guardrails
+
+- Inline comments: imperative voice, ≤ 3 lines unless quoting code. Example: `Untyped param. Add \`board: Board\` annotation per CLAUDE.md §5 code style.`
+- Reference `CLAUDE.md` / `docs/*` sections by path when invoking a project rule.
+- Never comment "LGTM" or approval praise. Clean PRs go through §4b (auto-merge if all gates pass) or get a tiny `body="No findings at <sha>."` comment if any gate fails.
+- Never push commits. Never re-label the original issue's Status (other than moving to Done after a successful auto-merge per §4b).
+- Don't review draft PRs (skip with note).
+- If CI is red on the PR, mention it in the review body but still review the diff.
+
+## 7. Local investigation via git worktree
+
+**Default: stay remote.** `gh pr diff` + `gh api .../contents` cover most reviews. Only spin up a worktree when one of these is true:
+
+- A **suspected blocker** needs cross-file context to confirm (e.g., "does anything else call this?")
+- You want to **run tests** to verify a finding (`godot --headless ... gut_cmdln.gd`)
+- You need to `Grep` the full repo at the PR's SHA
+
+### Setup (per PR, on demand)
+
+```bash
+PR=<pr_number>
+SHA=<headRefOid>
+WT=.pr-review-worktrees/pr-$PR
+
+# Concurrency lock — bail if another review is already in this worktree
+if [ -e "$WT/.lock" ]; then
+  echo "pr-$PR worktree busy, skipping local investigation"
+  exit 0
+fi
+
+# Fetch the PR head into a per-PR ref (avoids polluting branch list)
+git fetch origin "pull/$PR/head:refs/remotes/pr/$PR"
+
+# Add detached worktree at the PR's head SHA
+git worktree add --detach "$WT" "refs/remotes/pr/$PR"
+mkdir -p "$WT" && touch "$WT/.lock"
+```
+
+### Use it (NEVER `cd`)
+
+All commands use `-C` or `--path`:
+
+```bash
+git -C "$WT" log -1
+git -C "$WT" grep "pattern"
+godot --headless --path "$WT/godot" -s addons/gut/gut_cmdln.gd -gconfig=res://.gutconfig.json
+```
+
+Reasoning: other agents may share this session's cwd. Changing directory breaks them.
+
+### Teardown (always, even on failure)
+
+```bash
+rm -f "$WT/.lock"
+git worktree remove --force "$WT"
+git update-ref -d "refs/remotes/pr/$PR" 2>/dev/null || true
+```
+
+Wrap the investigation in a trap so teardown always runs:
+
+```bash
+trap 'rm -f "$WT/.lock"; git worktree remove --force "$WT" 2>/dev/null; git update-ref -d "refs/remotes/pr/$PR" 2>/dev/null' EXIT
+```
+
+### Inline comments still go through GitHub API
+
+The worktree only enables local exploration. Review comments still POST to `repos/.../pulls/<pr>/reviews` with `commit_id=<headRefOid>` — the PR's remote SHA, not anything local.
+
+## Failure modes
+
+- `gh project item-list` returns no `status` → field name might differ; fall back to GraphQL using field id `PVTSSF_lAHOAAnKBM4BWZYrzhRuER4`.
+- Linked PR is on a fork → inline comments still work; if the API rejects, fall back to a single general PR comment with all findings.
+- Network / auth error → print the error and stop; do **not** mutate state file on partial runs.
+- Worktree add fails (e.g., ref already checked out elsewhere) → skip local investigation, continue with remote-only review, note in summary.
+- Stale `.lock` from a crashed previous run → if the worktree dir exists but no `git worktree list` entry references it, the §0 cleanup removes it.

--- a/.claude/skills/gh-pr-review/wait-for-review-queue.py
+++ b/.claude/skills/gh-pr-review/wait-for-review-queue.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env -S uv run --quiet --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Block until at least one PR in the "In review" column has an unreviewed SHA.
+
+Used by the `gh-pr-review` skill as a gate: the skill calls this first so it
+only consumes Claude tokens when there's actual review work to do. Polls
+`gh project item-list` every 30s. Reuses `.gh-pr-review-state.json` (written
+by the skill) as the single source of truth for "already reviewed at SHA".
+
+Exit codes:
+  0 — work available; stdout is JSON {"prs": [{"issue": N, "pr": N, "sha": "..."}, ...]}
+  2 — gh CLI / network error after retries (skill should surface and stop)
+  130 — interrupted (Ctrl+C)
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO = "lubobill1990/little-games"
+PROJECT_OWNER = "lubobill1990"
+PROJECT_NUMBER = "5"
+
+
+def _repo_root() -> Path:
+    res = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True, text=True, check=False,
+    )
+    if res.returncode != 0:
+        print(f"[watch] not inside a git repo: {res.stderr.strip()}", file=sys.stderr)
+        sys.exit(2)
+    return Path(res.stdout.strip())
+
+
+STATE_FILE = _repo_root() / ".gh-pr-review-state.json"
+POLL_SECONDS = 60
+GH_RETRY_LIMIT = 3
+GH_RETRY_BACKOFF = 5
+ITEMS_PAGE_SIZE = 50
+
+# One GraphQL hit gets: board items (status + linked content) + each
+# linked PR's headRefOid. Replaces the old N+1 fan-out (project item-list →
+# gh issue view → gh pr view per issue).
+WORK_QUERY = """
+query($owner:String!, $number:Int!, $first:Int!) {
+  user(login: $owner) {
+    projectV2(number: $number) {
+      items(first: $first) {
+        nodes {
+          fieldValueByName(name: "Status") {
+            ... on ProjectV2ItemFieldSingleSelectValue { name }
+          }
+          content {
+            ... on Issue {
+              number
+              closedByPullRequestsReferences(first: 5, includeClosedPrs: false) {
+                nodes { number state headRefOid }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def log(msg: str) -> None:
+    print(f"[watch] {msg}", file=sys.stderr, flush=True)
+
+
+def run_gh(args: list[str]) -> str:
+    """Run a gh command with simple retry on transient failures."""
+    last_err = ""
+    for attempt in range(1, GH_RETRY_LIMIT + 1):
+        try:
+            res = subprocess.run(
+                ["gh", *args],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if res.returncode == 0:
+                return res.stdout
+            last_err = res.stderr.strip() or res.stdout.strip()
+        except FileNotFoundError:
+            log("gh CLI not found on PATH")
+            sys.exit(2)
+        log(f"gh {' '.join(args[:2])} failed (attempt {attempt}/{GH_RETRY_LIMIT}): {last_err}")
+        if attempt < GH_RETRY_LIMIT:
+            time.sleep(GH_RETRY_BACKOFF)
+    log(f"gh command exhausted retries: gh {' '.join(args)}")
+    sys.exit(2)
+
+
+def load_state() -> dict:
+    if not STATE_FILE.exists():
+        return {}
+    try:
+        return json.loads(STATE_FILE.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as e:
+        log(f"state file unreadable ({e}); treating as empty")
+        return {}
+
+
+def in_review_prs() -> list[tuple[int, int, str]]:
+    """One GraphQL call → list of (issue_number, pr_number, head_sha) for In review cards."""
+    out = run_gh([
+        "api", "graphql",
+        "-f", f"query={WORK_QUERY}",
+        "-F", f"owner={PROJECT_OWNER}",
+        "-F", f"number={PROJECT_NUMBER}",
+        "-F", f"first={ITEMS_PAGE_SIZE}",
+    ])
+    data = json.loads(out)
+    nodes = (
+        data.get("data", {}).get("user", {})
+        .get("projectV2", {}).get("items", {}).get("nodes", [])
+        or []
+    )
+    result: list[tuple[int, int, str]] = []
+    for node in nodes:
+        fv = node.get("fieldValueByName") or {}
+        if fv.get("name") != "In review":
+            continue
+        content = node.get("content") or {}
+        issue_num = content.get("number")
+        if not isinstance(issue_num, int):
+            continue
+        prs = (content.get("closedByPullRequestsReferences") or {}).get("nodes") or []
+        for pr in prs:
+            if pr.get("state") != "OPEN":
+                continue
+            pr_num = pr.get("number")
+            sha = pr.get("headRefOid")
+            if isinstance(pr_num, int) and isinstance(sha, str) and sha:
+                result.append((issue_num, pr_num, sha))
+                break
+    return result
+
+
+def find_work() -> list[dict]:
+    """Return list of {issue, pr, sha} for PRs whose head SHA has not been reviewed."""
+    state = load_state()
+    work: list[dict] = []
+    for issue, pr_num, sha in in_review_prs():
+        last = state.get(str(pr_num), {}).get("last_reviewed_sha")
+        if last != sha:
+            work.append({"issue": issue, "pr": pr_num, "sha": sha})
+    return work
+
+
+def log_active_identity() -> None:
+    res = subprocess.run(
+        ["gh", "api", "user", "--jq", ".login"],
+        capture_output=True, text=True, check=False,
+    )
+    who = res.stdout.strip() if res.returncode == 0 else f"<unknown: {res.stderr.strip()}>"
+    log(f"running as gh user: {who}")
+
+
+def main() -> int:
+    log_active_identity()
+    log(f"polling every {POLL_SECONDS}s; state={STATE_FILE}")
+    tick = 0
+    while True:
+        tick += 1
+        try:
+            work = find_work()
+        except KeyboardInterrupt:
+            return 130
+        if work:
+            log(f"tick {tick}: found {len(work)} PR(s) needing review")
+            print(json.dumps({"prs": work}))
+            return 0
+        log(f"tick {tick}: queue empty, sleeping {POLL_SECONDS}s")
+        try:
+            time.sleep(POLL_SECONDS)
+        except KeyboardInterrupt:
+            return 130
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/.claude/skills/implement-task/SKILL.md
+++ b/.claude/skills/implement-task/SKILL.md
@@ -1,0 +1,801 @@
+---
+name: implement-task
+description: Claim one Ready task from Project #5, implement its Dev plan in an isolated git worktree as `weavejamtom`, push a branch, open a PR, and move the card to In review. Skips tasks blocked by dependencies and posts a deduped blocker report to issue #9 when stuck. TRIGGER on `/implement-task` or via `/loop 15m /implement-task`.
+---
+
+# implement-task
+
+You are acting as the **task implementer** for `lubobill1990/little-games`. Honor the brevity contract in `CLAUDE.md`. Per run, claim **at most one** task — strict, no exceptions even if work finishes early.
+
+This skill is the symmetric counterpart of `gh-pr-review`. The user pushes work entirely from GitHub (Backlog → Ready); you turn Ready tasks into open PRs, then `gh-pr-review` reviews and merges them.
+
+## Per-tick priority order
+
+Each `/loop` tick walks this list and stops at the first match. Whatever it does, the tick exits — wait for the next wakeup.
+
+1. **§1a Resume in-progress work** — an `active` worktree exists from a prior, mid-flight tick (e.g., crashed during code/test/CI-wait).
+2. **§1c Handle a Changes-requested PR that hasn't been fixed yet** — reviewer asked for changes; nobody's pushed the fix. Goes into §11.
+3. **§1d Wait for the previously-shipped task to clear In review** — if §9 or §11g recorded a `pending_review`, block until that issue leaves the `In review` column before claiming anything new.
+4. **§2-§9 Claim a new Ready task.**
+
+If a higher-priority bucket fires, lower buckets are skipped this tick. This keeps the work strictly serialized and predictable for the human.
+
+A tick that pushes commits (§8 or §11g) blocks **in-tick** until CI returns a final verdict — see §12. The implementer is responsible for self-healing red CI; do not hand it off to the next tick.
+
+## Identity
+
+**All GitHub operations and git commits in this skill MUST run as the `weavejamtom` user.** Author/committer of every commit must be `Tom Lei <tom@weavejam.com>`. The `gh-pr-review` skill's auto-merge gate (§4b rule 4) hard-requires this — if the PR's author is anything else, no auto-merge.
+
+Pin this skill's identity to `weavejamtom` via the `GH_TOKEN` env var. **Do not use `gh auth switch`** — it mutates the user-level `~/.config/gh/hosts.yml`, which collides with the `gh-pr-review` skill running on the same machine. `GH_TOKEN` is process-scoped and overrides whatever account is "active", giving us race-free isolation.
+
+```bash
+export GH_TOKEN=$(gh auth token --user weavejamtom 2>/dev/null)
+[ -n "$GH_TOKEN" ] || { echo "weavejamtom not in gh keyring; run: gh auth login --user weavejamtom"; exit 1; }
+[ "$(gh api user --jq .login)" = "weavejamtom" ] || { echo "GH_TOKEN didn't resolve to weavejamtom"; exit 1; }
+```
+
+If the keyring lookup fails (account never logged in, or token revoked), STOP and post once-per-day to issue #9 (per §10 dedupe rules) with reason `gh_wrong_user` so the human can re-auth via `gh auth login --user weavejamtom`.
+
+`GH_TOKEN` lives only in the current Bash process — every `/loop` tick re-runs §0, so the export is fresh each time. All `gh` calls in §1–§12 inherit it.
+
+For git over https (the `git push` calls in §4 / §8 / §11g / §12), wire each new worktree's credential helper to the same token so push doesn't fall back to whatever credential the OS keychain has cached:
+
+```bash
+git -C "$WT" config --local credential.https://github.com.helper '!gh auth git-credential'
+# `gh auth git-credential` inherits GH_TOKEN from env → push uses weavejamtom's token.
+```
+
+Set the git author/committer identity **per-worktree** in §4 — never mutate global git config.
+
+## Inputs (hardcoded)
+
+- Repo: `lubobill1990/little-games`
+- Project: user `lubobill1990`, project number `5`, project node id `PVT_kwHOAAnKBM4BWZYr`
+- Status field id: `PVTSSF_lAHOAAnKBM4BWZYrzhRuER4` — Backlog `c159f539` · Ready `391bc048` · In progress `52594841` · In review `43a760f0` · Changes requested `4c71b2f8` · Done `bb829f92`
+- Priority field id: `PVTSSF_lAHOAAnKBM4BWZYrzhRuEWM` — P0 `79628723` · P1 `0a877460` · P2 `da944a9c`
+- Meta-blocker issue: **#9** (used to flag the human when no task is claimable)
+- Worktree root: `.implement-task-worktrees/` (gitignored). One subdir per task: `task-<n>`.
+- State file: `.implement-task-state.json` at repo root (gitignored). Kept outside `.claude/` so writes don't trigger settings-dir approval prompts. Schema:
+
+```json
+{
+  "active": {
+    "<issue_number>": {
+      "worktree": ".implement-task-worktrees/task-<n>",
+      "branch": "task/<n>-<slug>",
+      "started_at": "<iso>",
+      "last_step": "plan|coding|tests|pushed|pr_opened|cr_fixing|ci_waiting|ci_red_fixing"
+    }
+  },
+  "pending_review": {
+    "issue": <issue_number>,
+    "pr": <pr_number>,
+    "moved_to_in_review_at": "<iso>"
+  },
+  "blocked_global": {
+    "fingerprint": "<sorted joined blocker list>",
+    "posted_to_9_at": "<iso>"
+  }
+}
+```
+
+`pending_review` is the single most-recently-shipped task (issue moved to `In review` by §9 or §11g). On the next tick, §1d blocks until that issue leaves `In review` — see §1d for rationale. At most one `pending_review` exists at a time; it's cleared the moment §1d unblocks.
+
+`cr_*` last_step values are used by §11. `ci_waiting` / `ci_red_fixing` mean a §12 wait-for-CI loop was interrupted (process killed, machine rebooted) — §1a resumes those by re-entering §12 with the same PR.
+
+## Procedure
+
+### 0. Cleanup stale worktrees
+
+```bash
+git worktree prune
+ls .implement-task-worktrees/ 2>/dev/null | while read d; do
+  git worktree list --porcelain | grep -q ".implement-task-worktrees/$d" \
+    || rm -rf ".implement-task-worktrees/$d"
+done
+```
+
+Then run the §Identity check. If wrong account, jump to §10 (auth-wrong path) and stop.
+
+### 1. Resume / Changes-requested handling (priority order — first match wins, then exit)
+
+#### 1a. Resume mid-flight in-progress work
+
+Read the state file. If `active` has any entry:
+
+1. Pick the oldest by `started_at`.
+2. Verify the worktree dir exists, `.lock` file is present, and `git worktree list` includes it.
+3. Verify the linked issue is still on the board in `In progress` (or `Changes requested` for a §11 fix).
+4. If healthy → resume from the recorded `last_step`:
+   - `plan` / `coding` / `tests` → continue from §6.
+   - `pushed` / `pr_opened` → re-enter §12 (wait-for-CI) with the PR found via `gh pr list --head <branch>`.
+   - `cr_fixing` → continue from §11c.
+   - `ci_waiting` / `ci_red_fixing` → re-enter §12 with the recorded PR number. The wait-for-CI loop is idempotent.
+5. If unhealthy (worktree gone, board moved) → drop the `active` entry, fall through to §1c.
+
+Per the user's preference: finishing existing work beats claiming new work.
+
+#### 1c. Pick up an unfixed Changes-requested PR
+
+If §1a didn't fire, scan the board for cards in `Changes requested` whose linked PR is authored by `weavejamtom`:
+
+```bash
+gh project item-list 5 --owner lubobill1990 --format json --limit 100 \
+  | jq '[.items[] | select(.status == "Changes requested") | {n: .content.number}]'
+```
+
+For each, fetch `closedByPullRequestsReferences` and the PR's `author.login`; only consider PRs where author is `weavejamtom`. (PRs from a human or external contributor are out of scope — leave them alone.)
+
+If multiple match, pick the lowest-numbered issue (FIFO by issue id is good enough; this is a low-throughput shop).
+
+If one matches → §11 (the bulk of the Changes-requested workflow lives there). **Exit the tick** when §11 is done, regardless of whether it pushed.
+
+If none match → fall through to §1d.
+
+#### 1d. Wait for the previously-shipped task to clear In review
+
+Strict serialization: don't claim a new Ready task while the last one we shipped is still being reviewed. If the reviewer requests changes, that PR's needs come first (§1c will pick it up next tick); if it merges, we're free to start the next one.
+
+Read `state.pending_review`. If absent → fall through to §2.
+
+If present:
+
+```bash
+PENDING=<state.pending_review.issue>
+
+# Block until the issue leaves the In review column. Polls every 30s, no timeout.
+WAIT_OUT=$(uv run --quiet --script .claude/skills/implement-task/wait-for-issue-out-of-review.py $PENDING)
+RC=$?
+if [ $RC -ne 0 ]; then
+  echo "wait-for-review script exited $RC; aborting this tick"
+  exit $RC
+fi
+echo "$WAIT_OUT"  # JSON: {"issue": N, "status": "<new status or null>"}
+```
+
+The script's behavior matches `gh-pr-review`'s watch script: 60s polling via a single GraphQL call against Project #5, returns the moment the card's status is anything other than `In review`. Same Bash-tool 10-min cap caveat — wrap in the same 5-attempt retry loop as `gh-pr-review` SKILL.md §0:
+
+```bash
+PENDING=<state.pending_review.issue>
+WAIT_OUT=""
+for attempt in 1 2 3 4 5; do
+  WAIT_OUT=$(uv run --quiet --script .claude/skills/implement-task/wait-for-issue-out-of-review.py $PENDING)
+  RC=$?
+  if [ $RC -eq 0 ] && [ -n "$WAIT_OUT" ]; then
+    break
+  fi
+  if [ $RC -ne 0 ] && [ $RC -ne 124 ] && [ $RC -ne 143 ]; then
+    echo "wait script exited $RC; aborting this tick"
+    exit $RC
+  fi
+done
+if [ -z "$WAIT_OUT" ]; then
+  echo "still in review after 5×10min waits; exit cleanly so /loop can recycle"
+  exit 0
+fi
+```
+
+Once the script returns:
+
+1. Clear `state.pending_review`. Persist immediately.
+2. **Exit the tick.** The card's new status (`Changes requested` or `Done`) will be picked up by §1c or by `gh-pr-review`'s post-merge plumbing on the *next* tick. Re-running the priority list in the same tick risks racing with state that's only now propagating.
+
+Why exit instead of continuing to §2: the next tick's §1c is exactly the path that handles a freshly-`Changes requested` card; merging into the same tick muddies which step did what. The cost is one extra `/loop` cycle (≤ 1 min), which is negligible compared to review latency.
+
+### 2. Find the next claimable Ready task
+
+```bash
+gh project item-list 5 --owner lubobill1990 --format json --limit 100
+```
+
+Filter to `status == "Ready"`. Sort by Priority (P0 > P1 > P2 > unset), then by issue number ascending. Walk the list and return the first issue that passes §3.
+
+If none pass: go to §5 (post deduped blocker to #9), then exit with `No claimable tasks at this time.`
+
+### 3. Claim eligibility check
+
+For each Ready candidate, check in order. First failure → record the reason + skip.
+
+#### a. Already-claimed guard
+
+```bash
+gh issue view <n> --repo lubobill1990/little-games --json comments \
+  --jq '.comments | map(select(.author.login == "weavejamtom" and (.body | startswith("🔧 Claimed by implement-task skill at ")))) | .[-1].createdAt // empty'
+```
+
+If a sentinel exists newer than 4 hours → assume another agent owns it; skip with reason `claimed_elsewhere`.
+
+If older than 4h and the issue is still in Ready → assume the prior agent died; proceed (it'll get re-claimed).
+
+#### b. Dependency check
+
+Parse the issue body (and the `task.yml` template's "Depends on" field, which renders as a labeled section). Match `#\d+` references on lines containing `depends on` (case-insensitive) or under a `## Depends on` heading.
+
+For each dep `#N`:
+
+```bash
+gh issue view N --repo lubobill1990/little-games \
+  --json state,projectItems --jq '{state, status: (.projectItems[0].status.name // null)}'
+```
+
+- `state == "CLOSED"` → satisfied.
+- `state == "OPEN"` and `status == "Done"` → satisfied (auto-close lag).
+- `status == "In review"` → **NOT satisfied**. Reason: `depends_on_in_review:#N`. The whole point of `Depends on` is to wait for that PR to land.
+- `status == "Changes requested"` → **NOT satisfied**. Reason: `depends_on_changes_requested:#N`. The dep PR is being iterated on — wait.
+- `status` in `In progress|Ready|Backlog|null` → **NOT satisfied**. Reason: `depends_not_started:#N`.
+
+Any unsatisfied dep → skip task with the recorded reason.
+
+#### c. Branch conflict guard
+
+```bash
+git ls-remote --heads origin "task/<n>-*" | head -1
+```
+
+If anything matches → another worktree owns this issue's branch; skip with reason `branch_exists`.
+
+#### d. PRD / Dev plan presence
+
+Issue body must contain both a `## PRD` (or `# PRD`) section AND a `## Dev plan` (or `## Dev Plan`) section, each with non-empty body content. If either is missing → skip with reason `not_ready_no_plan`. We **do not** write PRDs from this skill — that's the Backlog → Ready refinement step.
+
+### 4. Claim and bootstrap
+
+For the chosen issue `<n>`:
+
+```bash
+TITLE=$(gh issue view <n> --repo lubobill1990/little-games --json title --jq .title)
+SLUG=$(echo "$TITLE" | tr '[:upper:] ' '[:lower:]-' | tr -cd 'a-z0-9-' | sed 's/--*/-/g; s/^-//; s/-$//' | cut -c1-40)
+WT=".implement-task-worktrees/task-<n>"
+BRANCH="task/<n>-$SLUG"
+
+# Post claim sentinel BEFORE any other mutation. Race window is small; combined
+# with §3a's 4-hour window this is good enough for a low-concurrency setup.
+gh issue comment <n> --repo lubobill1990/little-games \
+  --body "🔧 Claimed by implement-task skill at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# Sync with remote BEFORE branching. We base the worktree on origin/main, not
+# the host repo's local main, so we don't need (and don't want) to fast-forward
+# the host's checkout — the user may be on another branch with uncommitted work.
+# Pruning deleted refs avoids stale `task/*` branches confusing §3c next run.
+git fetch --prune origin
+
+# Sanity-check: origin/main must exist after fetch.
+git rev-parse --verify --quiet origin/main >/dev/null || {
+  echo "origin/main missing after fetch — aborting"; exit 1;
+}
+
+git worktree add -b "$BRANCH" "$WT" origin/main
+touch "$WT/.lock"
+
+# Per-worktree git identity. Do NOT use --global.
+git -C "$WT" config user.name "Tom Lei"
+git -C "$WT" config user.email "tom@weavejam.com"
+# Pin git push auth to the same GH_TOKEN this skill exported in §Identity.
+git -C "$WT" config --local credential.https://github.com.helper '!gh auth git-credential'
+
+scripts/board.sh <n> InProgress
+```
+
+Update state file: `active.<n> = { worktree, branch, started_at: <iso>, last_step: "plan" }`. Persist immediately so a crash leaves a recoverable trail.
+
+### 5. If unable to claim ANY task — post to issue #9, deduped
+
+This step runs once §3 has rejected every candidate. Build the **fingerprint** from the rejection reasons:
+
+```
+fingerprint = sorted(["#<n>:<reason>" for each rejected candidate]).join(",")
+```
+
+Read `state.blocked_global`:
+
+- If `fingerprint` matches AND `posted_to_9_at` is within the last 24 hours → **do not post**. Just exit silently with `Blocked, already reported.`
+- Otherwise → post a fresh comment on #9 and update state.
+
+Comment body template:
+
+```markdown
+🛑 implement-task skill cannot claim a task.
+
+**Blocked tasks:**
+- #<n> — <human reason>
+- ...
+
+Will retry on each `/loop` tick. To unblock: <one-line hint per common reason>.
+```
+
+Reason → human-text mapping:
+- `depends_on_in_review:#N` → "waiting on #N (currently In review — merge it)"
+- `depends_on_changes_requested:#N` → "waiting on #N (Changes requested — author needs to push the fix)"
+- `depends_not_started:#N` → "waiting on #N (not yet started — that one needs to be implemented first)"
+- `not_ready_no_plan` → "Ready but missing PRD or Dev plan section"
+- `branch_exists` → "branch `task/<n>-*` already exists on origin (orphaned worktree?)"
+- `claimed_elsewhere` → "another agent owns this within the last 4h"
+
+Then update state:
+
+```json
+"blocked_global": {
+  "fingerprint": "<the fingerprint>",
+  "posted_to_9_at": "<iso now>"
+}
+```
+
+Exit. Do not move any cards.
+
+### 6. Execute the Dev plan
+
+Read the issue body. Treat the `## Dev plan` section as the source of truth, the same way the `Plan` agent's plan file is treated in normal Claude Code use.
+
+Implement step by step using `Read`, `Edit`, `Write` with paths under `$WT/`. After each meaningful chunk:
+
+```bash
+git -C "$WT" add <files>
+git -C "$WT" commit -m "<conventional type>: <subject>
+
+Refs #<n>"
+```
+
+Conventional type per `CLAUDE.md` §5: `feat:` / `fix:` / `test:` / `chore:` / `docs:` / `refactor:` / `ci:`.
+
+Update `state.active.<n>.last_step` after each phase: `coding` → `tests` → `pushed`.
+
+Constraints:
+- Never amend a commit that has already been pushed.
+- Never `--force` push.
+- Never bypass hooks (`--no-verify`).
+- Per-game `core/` must not import `Node` or call OS/Engine APIs (`CLAUDE.md` §5).
+- GDScript must be statically typed (`CLAUDE.md` §5).
+
+### 7. Verify locally
+
+Run GUT tests in the worktree (CI runs the same command):
+
+```bash
+godot --headless --path "$WT/godot" -s addons/gut/gut_cmdln.gd \
+  -gconfig=res://.gutconfig.json
+```
+
+If tests pass → continue to §8.
+
+If tests fail → fix in the same worktree. Up to **3 fix iterations**. If still red after 3 attempts:
+- Comment on the **task issue** (not #9) with the failing test names + a brief "blocked, please advise".
+- Leave the card in `In progress` and the worktree intact.
+- Exit. The next `/loop` run's §1 will resume.
+
+### 8. Push and open PR
+
+```bash
+git -C "$WT" push -u origin "$BRANCH"
+```
+
+Update `last_step: pushed`.
+
+Compute effective diff size (mirrors `gh-pr-review` §4b rule 5):
+
+```bash
+TOTAL=$(git -C "$WT" diff --shortstat origin/main \
+  | grep -oE '[0-9]+ insertion|[0-9]+ deletion' \
+  | grep -oE '[0-9]+' | paste -sd+ - | bc)
+TOTAL=${TOTAL:-0}
+
+EXCLUDED=$(git -C "$WT" diff --numstat origin/main \
+  | awk '$3 ~ /^(godot\/)?tests\/|^(godot\/)?assets\/|^docs\/|\.import$|\.translation$|\.lock$|^[^/]+\.md$|^package-lock\.json$|^pnpm-lock\.yaml$/ \
+         {sum += $1 + $2} END {print sum+0}')
+
+EFFECTIVE=$((TOTAL - EXCLUDED))
+```
+
+Build the PR body. Include the `Estimated effective diff` line so `gh-pr-review` (and the human) can sanity-check:
+
+```markdown
+Closes #<n>
+
+## How tested
+- GUT tests pass locally in worktree
+- <other items pulled from the Dev plan's test strategy>
+
+## Estimated effective diff
+<EFFECTIVE> lines (total <TOTAL>, excluded <EXCLUDED>).
+```
+
+If `EFFECTIVE > 400`, append:
+
+```markdown
+⚠️ Exceeds 400 effective lines. Issue must carry the `large-pr-ok` label for auto-merge; otherwise human review will be required.
+```
+
+Open the PR:
+
+```bash
+gh pr create --repo lubobill1990/little-games \
+  --base main --head "$BRANCH" \
+  --title "<conventional title from first commit>" \
+  --body "$PR_BODY"
+```
+
+If `EFFECTIVE > 400` AND the issue lacks `large-pr-ok`, comment on the issue (not the PR — `gh-pr-review` owns PR comments):
+
+> ⚠️ This task produced a PR of `<EFFECTIVE>` effective lines (>400). Apply `large-pr-ok` to allow auto-merge, or split the task and I'll redo it on the next pass.
+
+Open the PR regardless — the human can decide.
+
+After `gh pr create` returns, capture `<PR>` and run **§12 (wait for CI)**. Only proceed to §9 once §12 reports green. If §12 escalates (timeout or 3 fix-iterations red), follow its exit rules — do NOT move the card to InReview.
+
+### 9. Move card and clean up
+
+```bash
+scripts/board.sh <n> InReview
+
+rm -f "$WT/.lock"
+git worktree remove --force "$WT"
+```
+
+Drop `state.active.<n>`. Clear `state.blocked_global` (we made progress, so the next blocked-state will be fresh). **Set `state.pending_review = { issue: <n>, pr: <pr>, moved_to_in_review_at: <iso> }`** so the next tick's §1d blocks until this card leaves `In review` (review approved & merged → Done, or reviewer requested changes → Changes requested).
+
+Print one-line summary:
+
+```
+Implemented #<n> "<title>" → PR #<pr> opened (eff=<n>, total=<n>).
+```
+
+### 10. Failure paths
+
+- **`gh auth token --user weavejamtom` returns empty** at §0 (account missing from keyring or token revoked): post-once-per-day to #9 with reason `gh_wrong_user`. Fingerprint dedupe applies. Stop.
+- **Worktree add fails** (e.g., branch exists despite §3c, or filesystem error): drop the candidate (don't `scripts/board.sh InProgress`), don't post the claim sentinel — actually, if the sentinel was already posted, post a corrective comment on the same issue: `❌ Claim aborted: <reason>. Skipping this run.` and try the next candidate.
+- **Tests fail after 3 iterations** (§7): comment on the task issue, leave In progress, exit.
+- **Push rejected** (branch protection, etc.): comment on the task issue with the error, leave In progress, exit.
+- **`gh pr create` fails**: same as push rejection. Don't move the card to InReview.
+- **Catastrophic uncaught error**: state file remains; next run's §1 picks it up. Don't try to "clean up" by deleting the worktree on uncertain failure paths — better a stuck task than lost work.
+
+### 11. Handle a Changes-requested PR (called from §1c)
+
+This section runs when there's a PR by `weavejamtom` whose linked issue is in `Changes requested` and we haven't yet pushed a fix. The job: read the reviewer's findings, fix what matters in code, route the rest into the rolling **Nit & minor cleanup** issue, push, and park for CI.
+
+**Restraint contract.** The user explicitly wants this skill to stay conservative:
+
+- **Always fix:** every `blocker` / `major` finding, plus any `minor` / `nit` that's a "举手之劳" — purely literal/stylistic edits (rename, typo, comment polish, removed unused var, missing type annotation, missing keycode in a list, single-line constant tweak).
+- **Defer to cleanup issue:** any `minor` / `nit` that requires multi-line refactor, new/changed tests, new abstraction, API rename across files, or design judgement.
+- **Never expand scope:** even if you spot something the reviewer missed, don't fix it on this pass. The PR is for the reviewer-flagged set only.
+
+#### 11a. Fetch the review and check out the PR branch
+
+```bash
+PR=<pr_number>
+N=<linked_issue>
+HEAD_BRANCH=$(gh pr view $PR --repo lubobill1990/little-games --json headRefName --jq .headRefName)
+HEAD_SHA=$(gh pr view $PR --repo lubobill1990/little-games --json headRefOid --jq .headRefOid)
+
+WT=".implement-task-worktrees/task-$N"
+git fetch origin "$HEAD_BRANCH"
+git worktree add "$WT" "origin/$HEAD_BRANCH"
+touch "$WT/.lock"
+git -C "$WT" checkout -B "$HEAD_BRANCH" "origin/$HEAD_BRANCH"
+git -C "$WT" config user.name "Tom Lei"
+git -C "$WT" config user.email "tom@weavejam.com"
+git -C "$WT" config --local credential.https://github.com.helper '!gh auth git-credential'
+```
+
+Update state: `active.<N> = { worktree: $WT, branch: $HEAD_BRANCH, started_at: <iso>, last_step: "cr_fixing" }`.
+
+#### 11b. Read the latest CHANGES_REQUESTED review
+
+The review body holds the summary; the inline comments are the actionable items.
+
+```bash
+# Latest CHANGES_REQUESTED review by lubobill1990
+REVIEW_ID=$(gh api repos/lubobill1990/little-games/pulls/$PR/reviews \
+  --jq '[.[] | select(.state == "CHANGES_REQUESTED" and .user.login == "lubobill1990")] | last | .id')
+
+# Body
+gh api repos/lubobill1990/little-games/pulls/$PR/reviews/$REVIEW_ID --jq .body
+
+# Inline comments (each has path, line, body, in_reply_to_id, etc.)
+gh api repos/lubobill1990/little-games/pulls/$PR/reviews/$REVIEW_ID/comments
+```
+
+For each inline comment, classify by reading the comment body:
+- `**Blocker**` / `Blocker —` → blocker
+- `**Major**` / `Major —` / `Missing` (when in review-skill format) → major
+- `**Minor**` / `Minor —` / `**Nit**` / `Nit —` → minor or nit
+- Otherwise infer from severity language ("must" / "required" / "violates" → major+; "consider" / "could" → minor)
+
+If the review body has a `### Nits` section without an inline location, treat each bullet as a nit finding.
+
+#### 11c. Fix blockers and majors
+
+Implement each blocker / major fix in `$WT` using `Read` / `Edit` / `Write`. Commit per logical fix:
+
+```bash
+git -C "$WT" add <files>
+git -C "$WT" commit -m "fix: <subject>
+
+Refs #$N"
+```
+
+Run GUT (same as §7) until green. Up to 3 fix iterations. If still red after 3 → comment on the **task issue** with the failing tests + "stuck after fix attempts; please advise". Leave card in `Changes requested`. **Exit the tick.**
+
+#### 11d. Triage minor / nit findings
+
+For each `minor` or `nit`:
+
+1. **举手之劳 test (one of these must hold):**
+   - The change is a single-token rename, comment fix, typo, missing keycode in a list, missing type annotation, removed dead var.
+   - The change touches one location, < 5 lines total, no new logic, no new tests.
+
+   If yes → fix it inline, commit it together with the blocker/major fixes (one commit per finding is fine, or batch as `chore: address review nits` if cohesive).
+
+2. **Otherwise → cleanup issue.** Collect into a list to be appended to the rolling `Nit & minor cleanup` issue in §11e.
+
+If you're unsure whether something qualifies, default to the cleanup issue — it's cheaper to defer than to expand scope mid-fix.
+
+#### 11e. Append deferred nits to the rolling cleanup issue (with dedup)
+
+This mirrors `gh-pr-review` SKILL.md §5b but is invoked from a different surface.
+
+1. Find the open rolling issue (label `nit-cleanup`, status Backlog):
+
+   ```bash
+   gh issue list --repo lubobill1990/little-games \
+     --label nit-cleanup --state open --json number,title,projectItems \
+     --jq '.[] | select(.projectItems[]? | .status.name == "Backlog") | .number' \
+     | head -1
+   ```
+
+2. **Dedup against existing content.** Fetch the issue body and all comments; build a set of existing finding identifiers. The identifier is `(file_path, line_number, normalized_title)` where `normalized_title` is lowercased, whitespace-collapsed, leading severity tag stripped.
+
+   ```bash
+   ROLLING=<n>
+   gh issue view $ROLLING --repo lubobill1990/little-games --json body --jq .body > /tmp/cleanup_body.md
+   gh api repos/lubobill1990/little-games/issues/$ROLLING/comments --jq '.[].body' >> /tmp/cleanup_body.md
+   ```
+
+   For each candidate finding to append, grep `/tmp/cleanup_body.md` for `<file>:<line>` AND a sufficient title-substring match (e.g. first 6 normalized words). If found → drop the candidate (already there, even if from this same PR's earlier review pass).
+
+3. If after dedup the candidate list is empty → skip §11e entirely; go to §11f.
+
+4. Build the batch block (same shape as gh-pr-review §5b step 2):
+
+   ```markdown
+   ### From PR #<pr> @ <short_sha> — <YYYY-MM-DD> (deferred by implement-task)
+
+   - [ ] **<file>:<line>** (<severity>) — <title>
+     <body>
+     [permalink](https://github.com/lubobill1990/little-games/blob/<HEAD_SHA>/<file>#L<line>)
+   ```
+
+5. **If a rolling issue exists:** append as a comment.
+   **If none exists:** create one with title `Nit & minor cleanup — batch starting <YYYY-MM-DD>`, label `nit-cleanup,backlog`, body matching the gh-pr-review §5b template, then add to Project #5 with Status=Backlog Priority=P2 (mutations from gh-pr-review §5).
+
+6. Capture `<cleanup_issue_url>` and `<batch_url>` (same rules as gh-pr-review §5b step 4).
+
+#### 11f. Backlink from the PR and the task issue
+
+If §11e actually appended anything, post the same note to both surfaces:
+
+```bash
+NOTE="🧹 Deferred <K> nit/minor finding(s) from this round to the rolling cleanup issue: <cleanup_issue_url> (batch: <batch_url>). Will be picked up there separately."
+
+gh issue comment $PR --repo lubobill1990/little-games --body "$NOTE"
+gh issue comment $N  --repo lubobill1990/little-games --body "$NOTE"
+```
+
+Skip both calls if §11e was a no-op.
+
+#### 11g. Push and wait for CI
+
+```bash
+git -C "$WT" push origin "$HEAD_BRANCH"
+```
+
+Update state: `active.<N>.last_step = "ci_waiting"`, record `cr_pushed_sha = <HEAD_SHA after push>`.
+
+Run **§12 (wait for CI)** with this `<PR>`. §12 owns the verdict — green / red-then-fixed / red-after-3-attempts / timeout — and updates state and the card per its own exit rules. On green, §12 moves the card to **InReview** so `gh-pr-review` (which only scans InReview cards) picks it up for the next round.
+
+When §12 returns, print the round summary:
+
+```
+#<N>: pushed fix on PR #<PR> (<X> blockers/majors fixed inline, <Y> nits inline, <Z> deferred to cleanup #<M>); CI <verdict>.
+```
+
+`<verdict>` is one of `green`, `red-then-fixed-green`, `red-after-3-attempts`, `timeout`.
+
+### 12. Wait for CI (subroutine called from §8 and §11g)
+
+Block in-tick on the PR's checks until they reach a final verdict, then act. The implementer is responsible for self-healing red CI; do **not** hand off to the next tick.
+
+**Inputs:** `<PR>` (the PR number), `<WT>` (the worktree path), `<N>` (linked issue), `<BRANCH>` (the head branch), call-site (§8 = new PR / §11g = CR fix). Caller has already set `last_step = "ci_waiting"` and persisted state.
+
+**Step 1 — compute the timeout.**
+
+```bash
+# Workflow file that runs the GUT suite — the gate we care about.
+WORKFLOW_FILE=".github/workflows/ci.yml"   # adjust if this repo uses a different filename
+
+# Last 5 successful runs on `main` (proxy for "healthy CI duration").
+MAX_SUCCESS=$(gh run list --repo lubobill1990/little-games \
+  --workflow "$WORKFLOW_FILE" --branch main --status success --limit 5 \
+  --json startedAt,updatedAt \
+  --jq '[.[] | (((.updatedAt|fromdateiso8601) - (.startedAt|fromdateiso8601)))] | max // 0')
+
+# Floor 600s (10 min). Cap 3600s (1h) — sanity bound; CI shouldn't legitimately exceed this.
+TIMEOUT_S=$(( MAX_SUCCESS * 2 ))
+[ "$TIMEOUT_S" -lt 600 ] && TIMEOUT_S=600
+[ "$TIMEOUT_S" -gt 3600 ] && TIMEOUT_S=3600
+```
+
+If the workflow file name differs, discover via `gh workflow list` and update the constant. If `gh run list` returns no successful samples (fresh repo / first PR), `MAX_SUCCESS=0` and the floor (600s) applies.
+
+**Step 2 — poll until terminal.** Every 20 seconds, query the rollup. Don't poll tighter than 20s — GitHub rate-limits and CI is minute-scale.
+
+```bash
+DEADLINE=$(( $(date +%s) + TIMEOUT_S ))
+VERDICT=""
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+  STATE=$(gh pr view "$PR" --repo lubobill1990/little-games \
+    --json statusCheckRollup \
+    --jq '[.statusCheckRollup[] | (.conclusion // .status // "PENDING")] as $s
+          | if ($s | length) == 0 then "NO_CHECKS"
+            elif any($s[]; . == "FAILURE" or . == "TIMED_OUT" or . == "CANCELLED" or . == "ACTION_REQUIRED") then "RED"
+            elif all($s[]; . == "SUCCESS" or . == "NEUTRAL" or . == "SKIPPED") then "GREEN"
+            else "PENDING" end')
+  case "$STATE" in
+    GREEN|RED|NO_CHECKS) VERDICT="$STATE"; break ;;
+  esac
+  sleep 20
+done
+[ -z "$VERDICT" ] && VERDICT="TIMEOUT"
+```
+
+`NO_CHECKS` is terminal — a PR with zero registered checks is a CI config problem, not a transient delay.
+
+**Step 3 — branch on the verdict.**
+
+- **GREEN.**
+  - **If `ci_fix_attempts >= 2`** (CI was red and required ≥2 attempts to go green) → run **step 5 (record CI lesson)** before continuing.
+  - Caller §8 (new PR): clear `last_step` and return `green`. §8 continues to §9 (move card to InReview, clean up).
+  - Caller §11g (CR fix): run `scripts/board.sh <N> InReview` (so `gh-pr-review` — which only scans InReview cards — picks the PR up for re-review), then clean up `rm -f $WT/.lock; git worktree remove --force $WT`, drop `active.<N>`, **set `state.pending_review = { issue: <N>, pr: <PR>, moved_to_in_review_at: <iso> }`** (same rationale as §9 — the next tick's §1d will gate on this). Return `green` (or `red-then-fixed-green` if step 4 ran).
+
+- **RED.**
+  - Pull failing-job logs:
+
+    ```bash
+    RUN_ID=$(gh pr view "$PR" --repo lubobill1990/little-games \
+      --json statusCheckRollup \
+      --jq '[.statusCheckRollup[] | select((.conclusion // "") == "FAILURE") | .detailsUrl] | .[0]' \
+      | grep -oE '/runs/[0-9]+' | grep -oE '[0-9]+')
+    gh run view "$RUN_ID" --repo lubobill1990/little-games --log-failed > "$WT/.ci-fail.log"
+    ```
+
+  - Set `last_step = "ci_red_fixing"`. Increment `ci_fix_attempts` in state (initialize to 0 on first red). Persist.
+  - If `ci_fix_attempts > 3` → escalate (step 4) with reason `red-after-3-attempts`.
+  - **Before fixing, consult `docs/lessons/index.md`** if it exists. Grep titles and one-line summaries for keywords from `.ci-fail.log` (the failing test name, error message phrase, file path involved). If a lesson matches, read the full lesson file first — past-me already paid for that knowledge. Don't blindly copy the fix; verify the symptom matches before applying.
+  - Otherwise: read `.ci-fail.log`, fix in `$WT` using `Read` / `Edit` / `Write`. Run GUT locally (§7) until green. Commit (`fix(ci): <subject>` — `Refs #<N>`). Push:
+
+    ```bash
+    git -C "$WT" push origin "$BRANCH"
+    ```
+
+  - Reset `last_step = "ci_waiting"`, persist, **loop back to step 1** (recompute deadline so each round gets a fresh timeout — CI duration depends on the run, not on prior wall time).
+
+- **NO_CHECKS** → escalate (step 4) with reason `no-checks`.
+- **TIMEOUT** → escalate (step 4) with reason `timeout`.
+
+**Step 4 — escalate.**
+
+```bash
+SUMMARY="Latest checks: $(gh pr checks "$PR" --repo lubobill1990/little-games || true)"
+
+gh issue comment "$N" --repo lubobill1990/little-games --body "🛑 implement-task: blocked on CI for PR #$PR — <reason>.
+
+$SUMMARY
+
+Worktree left intact at \`$WT\`; state preserved so the next \`/implement-task\` tick will resume the §12 loop. To unblock manually: push a fix to \`$BRANCH\` (next tick will re-poll and proceed) or close the PR (next tick will drop the worktree)."
+```
+
+Leave the worktree intact and `active.<N>` populated. Do NOT move the card. Return the reason to the caller. Caller exits the tick.
+
+**Idempotence.** §12 is safe to re-enter (§1a does this when a tick was killed mid-wait): step 1 recomputes the deadline; step 2 polls fresh; `ci_fix_attempts` persists across re-entries so the 3-attempt budget can't be reset by crashing.
+
+**Step 5 — record a CI lesson (only when `ci_fix_attempts >= 2`).**
+
+Goal: when CI took ≥ 2 fix rounds to go green, distill what was actually wrong into a teaching note future ticks can learn from. One-shot greens skip this step entirely — the noise isn't worth it.
+
+Lessons live in `docs/lessons/` as a hand-curatable knowledge base:
+
+- `docs/lessons/index.md` — one-line entries, oldest first, format `- [<short title>](<filename>) — <one-sentence what & how>`.
+- `docs/lessons/ci-<slug>.md` — one lesson per file. CI-related lessons MUST start with `ci-`; future lesson categories will get their own prefix (e.g. `gut-`, `gd-`).
+
+Procedure:
+
+1. **Gather evidence from this run.** `$WT/.ci-fail.log` is the *latest* failure log (each red round overwrites it); for the full picture, also pull commit messages added during the fix loop:
+
+   ```bash
+   FIX_COMMITS=$(git -C "$WT" log --format='%h %s' "origin/main..HEAD" -- | grep -iE '^[0-9a-f]+ fix(\(ci\))?:')
+   FIX_DIFF=$(git -C "$WT" log -p --format='### %h %s%n' "origin/main..HEAD" -- | head -300)
+   FAIL_LOG_TAIL=$(tail -200 "$WT/.ci-fail.log" 2>/dev/null)
+   ```
+
+2. **Decide if this round actually taught us something.** Skip recording (and just return `green`) if any of these hold:
+   - The failure was a transient infra blip (network timeout, runner pre-empted) and the fix was just a re-run with no code change.
+   - The fix is identical to a lesson already in `docs/lessons/index.md` — read the index first, grep titles for the failure signature.
+   - The lesson would be content-free (e.g. "fixed a typo"). The bar is "future me would want to know this before stepping on the same rake."
+
+3. **Author the lesson file.** Pick a short kebab-case slug describing the *root cause*, not the symptom. Examples of good slugs: `ci-headless-godot-needs-display-arg`, `ci-gut-flag-name-changed`, `ci-windows-path-separator-in-glob`. Avoid issue-numbered or PR-numbered slugs — the lesson should be reusable.
+
+   Write `docs/lessons/ci-<slug>.md` with this shape:
+
+   ```markdown
+   # <Title — same as slug, human-cased>
+
+   **First seen:** PR #<PR>, issue #<N>, <YYYY-MM-DD>
+   **Attempts to green:** <ci_fix_attempts>
+
+   ## Symptom
+
+   <2–4 sentence description of how the failure presented in CI — paste the key error line(s) verbatim from .ci-fail.log so future grep finds it>
+
+   ## Root cause
+
+   <what was actually wrong, in 1–3 sentences. NOT "I forgot to X" — write it so it's useful to a stranger>
+
+   ## Fix
+
+   <the actual change, with a code block if it's small enough. If multi-file, summarize and link to the merged commit SHAs>
+
+   ## How to avoid next time
+
+   <one or two bullets — concrete heuristic, e.g. "before adding a new GUT flag, check addons/gut/gut_cmdln.gd --help in the vendored version, not online docs">
+   ```
+
+   Use the gathered `FAIL_LOG_TAIL`, `FIX_COMMITS`, and `FIX_DIFF` as raw material. Write the markdown with `Write`, not `gh` — these are local files committed to the repo.
+
+4. **Update the index.** `docs/lessons/index.md` is the entry point; create it on first lesson. One-line entries, alphabetical by filename within each section. If the file doesn't exist, create with this header:
+
+   ```markdown
+   # Lessons
+
+   Hand-curated notes from past mistakes that took multiple rounds to diagnose. Organized by category; each entry links to a standalone `<category>-<slug>.md` file.
+
+   ## CI
+
+   - [<short title>](ci-<slug>.md) — <one-sentence summary>
+   ```
+
+   On subsequent lessons, insert under the appropriate category in alphabetical order. Keep each line under ~150 chars.
+
+5. **Commit the lesson alongside the CI fix.** This way the lesson lands on `main` together with the fix, and `git log docs/lessons/` becomes a chronological learning trail.
+
+   ```bash
+   git -C "$WT" add docs/lessons/index.md "docs/lessons/ci-<slug>.md"
+   git -C "$WT" commit -m "docs(lessons): record ci-<slug> from PR #$PR
+
+   Refs #$N"
+   git -C "$WT" push origin "$BRANCH"
+   ```
+
+   This push will trigger another CI round. **Do not** loop on it from inside step 5 — return to step 2's polling loop with `last_step = "ci_waiting"` and let the existing wait-for-CI machinery handle it. (The lesson commit is doc-only, so it should green on the first try; if it doesn't, that's a real CI issue worth another round.)
+
+6. After the lesson-commit CI round goes green, control returns here, but `ci_fix_attempts` is unchanged from before — and the lesson file already exists, so step 5's "skip if duplicate" guard in (2) prevents re-recording. Proceed to the GREEN branch's caller-specific cleanup as normal.
+
+**Why only `>= 2`:** a single red→green round usually means a typo or trivial oversight already captured by the commit message. Two or more rounds means I misdiagnosed at least once — that's where the learning is.
+
+## Style guardrails
+
+- All `gh` calls inherit the active account (verified `weavejamtom` at §0).
+- Never push `--force`, never `--amend` after push, never `--no-verify`.
+- Don't comment on PRs from this skill — `gh-pr-review` owns that channel.
+- Don't move cards beyond `InReview` — `gh-pr-review` moves to Done after merge.
+- Never modify global git config.
+- Per run, claim at most 1 task. If you finished a task in §1's resume path, do not also try to claim a new one — exit cleanly.
+- Always use `git -C "$WT"` and `--path "$WT/godot"`. Never `cd`. The session may be shared.
+
+## Concurrency notes
+
+This skill is designed to run alongside other instances of itself (different Claude sessions, future agent platforms). The guards:
+
+- Per-task worktree dir + `.lock` file.
+- Per-task branch name (`task/<n>-<slug>`) — push race resolved by `git push -u`.
+- Claim sentinel comment on the issue with 4-hour staleness window.
+- State file is local to one Claude session — DO NOT rely on it for cross-session coordination. The GitHub state (claim comment, board status, branch on origin) is the source of truth.
+
+If two instances race on §4, the second will fail at `git worktree add` (branch already taken) and back out via §10 — acceptable.

--- a/.claude/skills/implement-task/wait-for-issue-out-of-review.py
+++ b/.claude/skills/implement-task/wait-for-issue-out-of-review.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env -S uv run --quiet --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Block until a given Project #5 issue leaves the "In review" column.
+
+Used by the `implement-task` skill as a serialization gate: after pushing a PR,
+the skill records the issue number in `.implement-task-state.json` under
+`pending_review.issue`. On the next tick, before scanning Ready tasks (§2),
+the skill calls this script with that issue number. The script polls every 30s
+and only returns when the card is no longer in `In review` (typically: moved to
+`Changes requested` by the reviewer, or `Done` after merge).
+
+Usage:
+    wait-for-issue-out-of-review.py <issue_number>
+
+Exit codes:
+  0 — issue is no longer in In review; stdout is JSON {"issue": N, "status": "<new>"}
+  2 — gh CLI / network error after retries (skill should surface and stop)
+  3 — bad arguments
+  130 — interrupted (Ctrl+C)
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import time
+
+PROJECT_OWNER = "lubobill1990"
+PROJECT_NUMBER = "5"
+POLL_SECONDS = 60
+GH_RETRY_LIMIT = 3
+GH_RETRY_BACKOFF = 5
+ITEMS_PAGE_SIZE = 50
+
+# One GraphQL hit returns every card's status + linked issue number, so we can
+# locate the watched issue's status without `gh project item-list --limit 100`
+# (which pulls every field value on the board).
+STATUS_QUERY = """
+query($owner:String!, $number:Int!, $first:Int!) {
+  user(login: $owner) {
+    projectV2(number: $number) {
+      items(first: $first) {
+        nodes {
+          fieldValueByName(name: "Status") {
+            ... on ProjectV2ItemFieldSingleSelectValue { name }
+          }
+          content {
+            ... on Issue { number }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def log(msg: str) -> None:
+    print(f"[wait-review] {msg}", file=sys.stderr, flush=True)
+
+
+def run_gh(args: list[str]) -> str:
+    last_err = ""
+    for attempt in range(1, GH_RETRY_LIMIT + 1):
+        try:
+            res = subprocess.run(
+                ["gh", *args],
+                capture_output=True, text=True, check=False,
+            )
+            if res.returncode == 0:
+                return res.stdout
+            last_err = res.stderr.strip() or res.stdout.strip()
+        except FileNotFoundError:
+            log("gh CLI not found on PATH")
+            sys.exit(2)
+        log(f"gh {' '.join(args[:2])} failed (attempt {attempt}/{GH_RETRY_LIMIT}): {last_err}")
+        if attempt < GH_RETRY_LIMIT:
+            time.sleep(GH_RETRY_BACKOFF)
+    log(f"gh command exhausted retries: gh {' '.join(args)}")
+    sys.exit(2)
+
+
+def status_of(issue: int) -> str | None:
+    """Return the Project #5 status name for `issue`, or None if not on the board."""
+    out = run_gh([
+        "api", "graphql",
+        "-f", f"query={STATUS_QUERY}",
+        "-F", f"owner={PROJECT_OWNER}",
+        "-F", f"number={PROJECT_NUMBER}",
+        "-F", f"first={ITEMS_PAGE_SIZE}",
+    ])
+    data = json.loads(out)
+    nodes = (
+        data.get("data", {}).get("user", {})
+        .get("projectV2", {}).get("items", {}).get("nodes", [])
+        or []
+    )
+    for node in nodes:
+        content = node.get("content") or {}
+        if content.get("number") != issue:
+            continue
+        fv = node.get("fieldValueByName") or {}
+        return fv.get("name")
+    return None
+
+
+def log_active_identity() -> None:
+    res = subprocess.run(
+        ["gh", "api", "user", "--jq", ".login"],
+        capture_output=True, text=True, check=False,
+    )
+    who = res.stdout.strip() if res.returncode == 0 else f"<unknown: {res.stderr.strip()}>"
+    log(f"running as gh user: {who}")
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: wait-for-issue-out-of-review.py <issue_number>", file=sys.stderr)
+        return 3
+    try:
+        issue = int(sys.argv[1])
+    except ValueError:
+        print(f"issue number must be an integer, got: {sys.argv[1]}", file=sys.stderr)
+        return 3
+
+    log_active_identity()
+    log(f"watching issue #{issue}; polling every {POLL_SECONDS}s")
+    tick = 0
+    while True:
+        tick += 1
+        try:
+            status = status_of(issue)
+        except KeyboardInterrupt:
+            return 130
+        if status != "In review":
+            shown = status if status is not None else "(not on board)"
+            log(f"tick {tick}: issue #{issue} is now '{shown}', returning")
+            print(json.dumps({"issue": issue, "status": status}))
+            return 0
+        log(f"tick {tick}: still In review, sleeping {POLL_SECONDS}s")
+        try:
+            time.sleep(POLL_SECONDS)
+        except KeyboardInterrupt:
+            return 130
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ Thumbs.db
 # these are per-machine and must never land in the repo).
 .lock
 .claude/gh-pr-review-state.json
+.claude/scheduled_tasks.lock
+.claude/settings.local.json
+**/__pycache__/
 .gh-pr-review-state.json
 .pr-review-worktrees/
 .implement-task-state.json


### PR DESCRIPTION
Track the implement-task / gh-pr-review / gh-nit-cleanup skill source files under git for the first time. Until now `git ls-files | grep .claude` returned nothing — skill source lived only on each contributor's machine.

This unblocks #60 (refactor implement-task SKILL.md): a PR cannot modify, add, or delete files at paths that aren't part of the working tree. Tried to claim #60 in a prior tick and had to abort with that exact reason — see https://github.com/lubobill1990/little-games/issues/60#issuecomment-4366600385.

## What's tracked

- `.claude/skills/gh-pr-review/SKILL.md` + `wait-for-review-queue.py`
- `.claude/skills/gh-nit-cleanup/SKILL.md`
- `.claude/skills/implement-task/SKILL.md` + `wait-for-issue-out-of-review.py`

Verbatim snapshot of what's currently running locally — no skill behavior change.

## What stays per-machine (`.gitignore`)

Already-ignored: `.lock`, `.claude/gh-pr-review-state.json`, `.implement-task-state.json`, `.implement-task-worktrees/`, etc.

Added in this PR:
- `.claude/scheduled_tasks.lock` — runtime advisory lock
- `.claude/settings.local.json` — per-machine Claude Code permission allowlist
- `**/__pycache__/` — Python bytecode caches under skill dirs

## How tested

- `git -C \$WT status` after `git add .gitignore .claude/` shows exactly the 6 expected paths (3 SKILL.md + 2 .py + .gitignore). No `__pycache__`, no `settings.local.json`, no `scheduled_tasks.lock` — confirming the ignores work.
- Built in a fresh worktree off `origin/main` (not piggy-backed on any existing branch).

## Estimated effective diff

2093 lines added across 6 files. Five of those are skill source (operational tooling, not gameplay code) — large by line count, but each file is single-purpose and self-contained. \`.gitignore\` adds 3 lines.